### PR TITLE
:sparkles: Open-now filter chip + design system doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+Directory of laptop-friendly cafés and coworking spots in Leuven. Vue 3 + Vite + Leaflet, no backend. Space data lives in `src/data/spaces.json`.
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. The
+skill has multi-step workflows, checklists, and quality gates that produce better
+results than an ad-hoc answer. When in doubt, invoke the skill. A false positive is
+cheaper than a false negative.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke /office-hours
+- Strategy, scope, "think bigger", "what should we build" → invoke /plan-ceo-review
+- Architecture, "does this design make sense" → invoke /plan-eng-review
+- Design system, brand, "how should this look" → invoke /design-consultation
+- Design review of a plan → invoke /plan-design-review
+- Developer experience of a plan → invoke /plan-devex-review
+- "Review everything", full review pipeline → invoke /autoplan
+- Bugs, errors, "why is this broken", "wtf", "this doesn't work" → invoke /investigate
+- Test the site, find bugs, "does this work" → invoke /qa (or /qa-only for report only)
+- Code review, check the diff, "look at my changes" → invoke /review
+- Visual polish, design audit, "this looks off" → invoke /design-review
+- Developer experience audit, try onboarding → invoke /devex-review
+- Ship, deploy, create a PR, "send it" → invoke /ship
+- Merge + deploy + verify → invoke /land-and-deploy
+- Configure deployment → invoke /setup-deploy
+- Post-deploy monitoring → invoke /canary
+- Update docs after shipping → invoke /document-release
+- Weekly retro, "how'd we do" → invoke /retro
+- Second opinion, codex review → invoke /codex
+- Safety mode, careful mode, lock it down → invoke /careful or /guard
+- Restrict edits to a directory → invoke /freeze or /unfreeze
+- Upgrade gstack → invoke /gstack-upgrade
+- Save progress, "save my work" → invoke /context-save
+- Resume, restore, "where was I" → invoke /context-restore
+- Security audit, OWASP, "is this secure" → invoke /cso
+- Make a PDF, document, publication → invoke /make-pdf
+- Launch real browser for QA → invoke /open-gstack-browser
+- Import cookies for authenticated testing → invoke /setup-browser-cookies
+- Performance regression, page speed, benchmarks → invoke /benchmark
+- Review what gstack has learned → invoke /learn
+- Tune question sensitivity → invoke /plan-tune
+- Code quality dashboard → invoke /health

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,13 +4,34 @@ The canonical reference for visual language on Leuven Coworking Cafes. Keep this
 
 Brand mood: _neighbourhood cafe directory_, not tech product. Warm paper-cream backgrounds, navy for authority, orange for action. Serif body type for the "printed-guide" feel; emoji prefixes on interactive controls for a handmade voice.
 
+## How to use this doc
+
+- **Adding a new colour?** Check **Palette** first. If it's not there, either it maps to an existing hue (use that) or it's a new token — add a row here before you ship.
+- **Building a new component?** Read **Component conventions** — button shape, focus ring, touch-target minimum, and emoji-prefix rule are all prescriptive.
+- **Auditing contrast or keyboard nav?** See **Accessibility baseline**.
+- **Wondering why palette values aren't `bg-primary`?** That's in **Design debt** — it's known, not accidental.
+
+Rules in this doc are **prescriptive** unless marked otherwise. Anything under "Design debt" is a known gap with a plan.
+
+## Contents
+
+1. [Palette](#palette) — brand / surfaces / text / semantic hues, with why each exists
+2. [Typography](#typography) — two faces, Tailwind scale, no custom ramp
+3. [Layout & responsive](#layout--responsive) — breakpoints, container, grids, spacing
+4. [Component conventions](#component-conventions) — extending the system, iconography, variants, states, motion
+5. [Accessibility baseline](#accessibility-baseline) — contrast pairs, aria patterns, keyboard, reduced motion
+6. [Open questions](#open-questions) — design forks we haven't picked yet
+7. [Design debt](#design-debt) — known gaps with a plan to close them
+
 ---
 
 ## Palette
 
-All values are currently inlined as hex literals in Tailwind bracket classes (e.g. `bg-[#1a365d]`). Named CSS custom properties exist in `src/style.css` but are unused by components. See **Design debt** at the bottom.
+Scope is deliberately narrow: **two brand hues** (navy for authority, orange for action), **warm neutrals** for surfaces (cream + warm-grey borders), **cool greys** for text, and **Tailwind defaults** for status. Any new hex outside these four groups is a red flag — first ask whether an existing token covers it.
 
 ### Brand
+
+_Why these two:_ navy reads as "editorial / guide," orange is the only true accent and is reserved for calls-to-action and active-state affordance. Don't introduce a secondary accent.
 
 | Role           | Hex       | Used as                                                   |
 | -------------- | --------- | --------------------------------------------------------- |
@@ -22,6 +43,8 @@ All values are currently inlined as hex literals in Tailwind bracket classes (e.
 
 ### Surfaces
 
+_Why warm neutrals:_ cream evokes printed-guide / book paper and separates us from the flat-white tech-product default. Never substitute a cool grey.
+
 | Role            | Hex       | Used as                                                          |
 | --------------- | --------- | ---------------------------------------------------------------- |
 | Cream (default) | `#fffaf0` | Page background                                                  |
@@ -31,6 +54,8 @@ All values are currently inlined as hex literals in Tailwind bracket classes (e.
 | Cool border     | `#cbd5e0` | Form control borders, dashed empty-state border, header subtitle |
 
 ### Text
+
+_Why cool greys on warm surfaces:_ a small temperature contrast makes body text feel distinct without losing warmth. Pure black would feel harsh against cream; navy for body would compete with headings.
 
 | Role           | Hex       | Used as                                              |
 | -------------- | --------- | ---------------------------------------------------- |
@@ -42,6 +67,8 @@ All values are currently inlined as hex literals in Tailwind bracket classes (e.
 | White          | `#ffffff` | Text on navy/orange fills                            |
 
 ### Semantic (SpaceSummary trust indicators)
+
+_Why Tailwind defaults:_ status colours should look like "standard status colour" to anyone. Re-skinning green/yellow/red for a side project signals arbitrariness and breaks learned expectations.
 
 | Role           | Hex       | Signal                      |
 | -------------- | --------- | --------------------------- |
@@ -67,9 +94,47 @@ Scale is pure Tailwind (`text-xs`/`sm`/`base`/`lg`/`xl`/`2xl`/`4xl`/`5xl`). No c
 
 ---
 
+## Layout & responsive
+
+**Breakpoints.** Tailwind defaults, no custom: `sm` (640px), `md` (768px), `lg` (1024px), `xl` (1280px). `2xl` is not used anywhere — don't introduce it without cause.
+
+**Container width.** Every top-level section (header, `<main>`, footer) uses `max-w-6xl` (~72rem / 1152px) with `mx-auto`. Any new top-level surface should use the same — never full-width, never narrower. The only other max is `sm:max-w-md` on the footer CTA cards (constrains the two side-by-side call-outs on desktop).
+
+**Grid conventions.**
+
+| Where                     | Breakpoint stack                                    |
+| ------------------------- | --------------------------------------------------- |
+| Space card grid           | `grid-cols-1 md:grid-cols-2 xl:grid-cols-3`         |
+| Filter bar controls       | `grid-cols-2 md:grid-cols-4 lg:grid-cols-7`         |
+| Footer CTA row            | `flex-col sm:flex-row`                              |
+
+**Spacing scale.** Pure Tailwind (`p-*`, `gap-*`, `space-*`). No custom tokens. Common patterns:
+- Page padding: `px-4 sm:px-6` on the header, `px-6` on `<main>` and footer.
+- Toolbar gap: `gap-2 sm:gap-3`.
+- Grid gap: `gap-6` on space cards, `gap-4` on filter inputs.
+
+---
+
 ## Component conventions
 
-**Emoji prefix on buttons.** Interactive controls in the toolbar lead with a single emoji to signal function at a glance:
+**Extending the system.** Before adding a new shape, variant, or colour, run this test:
+
+1. Does an existing token cover it? If yes, use it.
+2. Is the new thing used in _more than one place_? If no, reconsider — one-offs belong in the component file, not the system.
+3. Can you name it in brand terms (navy, cream-surface, …) rather than generic ones (blue-500, bg-light)? If no, it probably doesn't belong in the palette.
+4. Does it have a clear _why_ you could add to this doc? If no, don't ship it.
+
+These questions replace the bare "don't add a third radius without a reason" rule — they're what counts as a reason.
+
+**Iconography (emoji) policy.** Toolbar controls lead with a single emoji to signal function at a glance. Rules when picking one:
+
+- One glyph per control. No combos.
+- **Literal over abstract** — `🗺️` for map, not `🌍`. `📋` for list, not `📝`. Prefer what the button *does*, not a metaphor.
+- No flags, no skin-tone modifiers, no gendered glyphs.
+- Reserved-meaning glyphs: ☀️/⛅/🌧️/❄️/🌫️ mean "weather-driven UI state" — don't reuse them for non-weather controls.
+- If no emoji feels right, don't force one — leave the label alone rather than ship something off-brand.
+
+Current inventory:
 
 | Control         | Glyph  |
 | --------------- | ------ |
@@ -82,20 +147,89 @@ Keep this convention for any new toolbar control — it's the main visual person
 
 **Touch targets.** Controls that can be tapped on mobile use `min-h-[44px]` (Apple HIG). Toolbar buttons currently inherit enough padding; OpenNowChip enforces it explicitly — do the same for any new chip.
 
+**Button shape & padding.** Three recipes in use:
+
+| Role                                 | Classes                                                           |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| Primary toolbar chip (Filters, OpenNow) | `rounded-lg border-2 px-3 py-2 text-sm font-medium`               |
+| Segmented toggle (List / Map)        | `rounded-lg border-2 px-4 py-2 text-sm font-medium` on the wrapper, inner `px-4 py-2` per segment |
+| Inline tag / tertiary                | `rounded` (4px radius), padding scales with context               |
+
+Don't introduce a third radius without running the "extending the system" test above.
+
+**Button variants.** Three variants in use — keep to these:
+
+| Variant    | Default                                           | Active / pressed                                  | Hover                          |
+| ---------- | ------------------------------------------------- | ------------------------------------------------- | ------------------------------ |
+| Navy chip  | `border-[#1a365d] bg-white text-[#1a365d]`        | `border-[#1a365d] bg-[#1a365d] text-white`        | `hover:bg-[#f5f0e6]` (inactive) / `hover:bg-[#15284a]` (active) |
+| Orange CTA | `bg-[#ed8936] text-white` (no border)             | n/a (CTAs don't toggle)                           | `hover:bg-[#dd7826]`           |
+| Ghost      | `bg-white text-[#1a365d]` (no border)             | n/a                                               | `hover:bg-[#f5f0e6]`           |
+
+**Interactive states.** All clickable elements handle these five states (not all apply to every control):
+
+- **Default** — resting look, documented above.
+- **Hover** — always a bg swap, never transform/scale. Keep the footprint stable.
+- **Active / pressed** — use `aria-pressed` on toggles; flip to the filled variant.
+- **Focus** — orange ring (see below). Mandatory, never `outline-none` without replacement.
+- **Disabled / loading** — `disabled:opacity-60 disabled:cursor-not-allowed` and/or a loading label prefix (see OpenNowChip's `⏳` state). Spinners are not in the system — use an emoji or text cue.
+
 **Focus.** Active focus ring is orange: `focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:ring-offset-2 focus-visible:outline-none`. Use this pattern on all new interactive elements, not the browser default.
 
-**Button shape.** `rounded-lg border-2` for primary action chips, `rounded` (4px) for smaller tertiary buttons and tags. Don't introduce a third radius without a reason.
+**Motion.** Three tokens, and no more:
 
-**Card shape.** `rounded-lg border-2 border-[#e2d9c8]` + white bg + hover-orange border + hover-lg shadow. Any new card-like surface should follow this pattern.
+| Token                                   | Where                                       |
+| --------------------------------------- | ------------------------------------------- |
+| `transition-colors` (Tailwind default ~150ms) | Toolbar buttons, links, form controls — bg/border swaps on hover/active |
+| `transition-all duration-200`           | Card hover (border + shadow together) — `SpaceCard`, `SpaceSummary` |
+| `transition-all duration-500 ease-out`  | `VisitProgress` bar fill only — slow, deliberate progress signal |
+
+No `transform` transitions, no `scale`/`translate` on hover, no new easing curves. The paper-guide mood means motion is subtle and functional — never decorative.
+
+**Card shape.** `rounded-lg border-2 border-[#e2d9c8]` on a white bg.
+- **Default** — cream border, no shadow.
+- **Hover** — border swaps to `#ed8936` (orange), `shadow-lg` lifts the card. Driven by `transition-all duration-200` (see Motion).
+- No focus state on cards themselves — interactive elements *inside* cards carry the focus ring instead.
+
+**Toolbar layout.** Horizontal controls use `flex flex-wrap items-center gap-2 sm:gap-3` so the toolbar wraps cleanly at 375px without horizontal scroll. Any new toolbar control should inherit this — don't add `flex-nowrap`.
 
 ---
 
 ## Accessibility baseline
 
-- Contrast: navy-on-white, white-on-navy, orange-on-white all pass WCAG AA at the sizes used. Orange-on-cream (`#ed8936` on `#f5f0e6`) is borderline — keep it for accents only, never for body copy.
-- `aria-pressed` for toggle buttons (OpenNowChip pattern).
-- `aria-label` where the visible text is emoji-heavy or ambiguous.
-- Keyboard nav: every interactive element is tab-reachable, focus ring must remain visible.
+**Contrast.** WCAG AA at the sizes used (16px+ body, 14px small). Specifically confirmed safe:
+
+| Pair                             | Use                                | Status                                           |
+| -------------------------------- | ---------------------------------- | ------------------------------------------------ |
+| Navy `#1a365d` on white          | Headings, body on cards            | AA / AAA                                         |
+| White on navy `#1a365d`          | Header, filled toggle buttons      | AA / AAA                                         |
+| Orange `#ed8936` on white        | CTA bg fill, focus ring            | AA for 14px+ bold and all 18px+                  |
+| Body muted `#4a5568` on cream    | Card body copy                     | AA                                               |
+| Orange `#ed8936` on cream `#f5f0e6` | **Accents only**                | Borderline — fails AA for body-sized text. Never for paragraphs. |
+
+**Screen reader patterns.**
+
+- Toggle buttons: `aria-pressed="true/false"` (see `OpenNowChip.vue`).
+- Emoji-prefixed labels: the emoji itself is decoration — wrap in `<span aria-hidden="true">` so it doesn't get announced as "sun with face" before the actual label.
+- Ambiguous or loading-state text: add `aria-label` with the full plain-English meaning.
+- Live updates (filter counts, loaded states): today there are none — if you add any, use `aria-live="polite"`.
+
+**Keyboard.** Every interactive element is tab-reachable in source order. Focus-visible ring (orange, see Component conventions) must remain visible — no `outline: none` without a replacement ring. Space/Enter toggles any `<button>`; keep semantic elements rather than `div`-with-click.
+
+**Touch targets.** 44×44 CSS px minimum (Apple HIG). See `min-h-[44px]` rule in Component conventions.
+
+**Reduced motion.** Not currently implemented. The `duration-200` card hover and `duration-500` progress fill will play for everyone regardless of `prefers-reduced-motion`. Low-priority debt — transitions are subtle — but should be fixed before adding any transform-based animations. See **Design debt**.
+
+---
+
+## Open questions
+
+Design forks the project hasn't resolved. Not debt (debt has a plan) — these are genuine choices waiting for the situation that forces them.
+
+- **Secondary accent colour.** Today orange is the only accent. If we ever need "info" or "neutral emphasis" that isn't a status signal, do we add a third brand hue or push harder on typography/weight? Push on type first.
+- **Map marker styling.** `MapView.vue` uses Leaflet default markers. They don't match the palette. Options: (a) custom orange pin, (b) small cafe-emoji marker, (c) leave default until the map becomes a core surface. Currently (c).
+- **Metadata icons vs. emoji policy.** `SpaceSummary` shows coloured dots and wifi-speed indicators — these are _semantic indicators_, not the emoji-button iconography. The doc's emoji policy doesn't apply to them. If we ever add true inline icons (Lucide / Heroicons), they'd be a new iconography category. Decide the icon library before shipping the first one.
+- **Copy voice.** The brand mood paragraph implies a "printed-guide" voice but there's no rubric (sentence length, formality, Oxford comma, you-vs-we). Empty-state copy in `SpaceList.vue` has one style; the footer has another. Tolerable for now; codify if the surface area grows.
+- **Dark mode.** Cross-referenced in Design debt. Open question: is cream-first identity still recognisable in dark mode, or does it need a full re-skin? Defer until user demand.
 
 ---
 
@@ -107,4 +241,6 @@ Keep this convention for any new toolbar control — it's the main visual person
     2. Move to Tailwind 4 `@theme` block in `style.css` — registers real design tokens so classes like `bg-primary` / `text-accent` work natively. Recommended.
   - Scope: ~30 min, touches every component but only via find-and-replace.
 - **Hues outside the seven named vars** (navy-hover, navy-track, cream-deep, warm-border, cool-border, cream-surface, orange-hover, ink, body-muted, placeholder) need names before we can promote to tokens — hence this doc.
+- **No `prefers-reduced-motion` handling.** All transitions play regardless of OS setting. Low-priority for current motion set (subtle fades) but will become a real issue if we ever add transform/scale. Fix: add a `motion-reduce:transition-none` variant to the motion tokens in Component conventions. ~10 min.
+- **Focus-ring rule not universally applied.** The prescribed `focus-visible:ring-2 focus-visible:ring-[#ed8936]` pattern lives only on `OpenNowChip.vue`. `FilterBar.vue` selects use `focus:border-[#ed8936] focus:outline-none` (no ring — relies on border colour change only); sort buttons have no focus treatment at all. Consequence: keyboard users on the filter panel get a weaker focus cue than on the chip. Fix: audit all interactive elements, apply the prescribed ring pattern. ~15 min.
 - **No dark mode.** Cream-first palette doesn't currently map to a dark counterpart. Defer until there's a user ask.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,110 @@
+# Design system
+
+The canonical reference for visual language on Leuven Coworking Cafes. Keep this doc in sync when palette, type, or component-level conventions change.
+
+Brand mood: _neighbourhood cafe directory_, not tech product. Warm paper-cream backgrounds, navy for authority, orange for action. Serif body type for the "printed-guide" feel; emoji prefixes on interactive controls for a handmade voice.
+
+---
+
+## Palette
+
+All values are currently inlined as hex literals in Tailwind bracket classes (e.g. `bg-[#1a365d]`). Named CSS custom properties exist in `src/style.css` but are unused by components. See **Design debt** at the bottom.
+
+### Brand
+
+| Role           | Hex       | Used as                                                   |
+| -------------- | --------- | --------------------------------------------------------- |
+| Navy (primary) | `#1a365d` | Header bg, active controls, body headings, borders        |
+| Navy hover     | `#15284a` | Hover state on active navy buttons (OpenNowChip only)     |
+| Navy track     | `#2d4a7c` | Progress bar track behind the orange fill (VisitProgress) |
+| Orange         | `#ed8936` | CTA buttons, active-state accent, badges, focus rings     |
+| Orange hover   | `#dd7826` | Hover state on orange CTAs                                |
+
+### Surfaces
+
+| Role            | Hex       | Used as                                                          |
+| --------------- | --------- | ---------------------------------------------------------------- |
+| Cream (default) | `#fffaf0` | Page background                                                  |
+| Cream surface   | `#f5f0e6` | FilterBar panel, footer bg, card hover bg, map empty-state veil  |
+| Cream deep      | `#faf5eb` | Card quote-block bg (SpaceSummary description)                   |
+| Warm border     | `#e2d9c8` | SpaceCard border, footer top border, tag borders                 |
+| Cool border     | `#cbd5e0` | Form control borders, dashed empty-state border, header subtitle |
+
+### Text
+
+| Role           | Hex       | Used as                                              |
+| -------------- | --------- | ---------------------------------------------------- |
+| Ink            | `#1a202c` | Form control value text (default body is inherited)  |
+| Body muted     | `#4a5568` | SpaceCard body copy, description italic              |
+| UI muted       | `#718096` | Secondary metadata, labels, footnotes                |
+| Placeholder    | `#a0aec0` | Empty-state secondary line                           |
+| Inverse muted  | `#cbd5e0` | Muted text on navy bg (header subtitle, VisitProgress) |
+| White          | `#ffffff` | Text on navy/orange fills                            |
+
+### Semantic (SpaceSummary trust indicators)
+
+| Role           | Hex       | Signal                      |
+| -------------- | --------- | --------------------------- |
+| Success        | `#22c55e` | Verified / fast / good      |
+| Warning        | `#eab308` | Medium / tentative          |
+| Danger         | `#ef4444` | Slow / missing / bad        |
+| Unknown        | `#9ca3af` | Not-yet-rated gray          |
+
+These match Tailwind 3 defaults (`green-500`, `yellow-500`, `red-500`, `gray-400`). Keep them — they read as "standard status colour" to anyone who's seen Tailwind.
+
+---
+
+## Typography
+
+Loaded via Google Fonts link in `index.html`; declared in `src/style.css`.
+
+| Token        | Family                          | Weight | Where                                      |
+| ------------ | ------------------------------- | ------ | ------------------------------------------ |
+| Display      | `Playfair Display`, Georgia     | 700    | `.font-display` utility on `<h1>`, `<h2>`  |
+| Body (base)  | `Crimson Pro`, Georgia          | 400    | Applied globally via `body` rule           |
+
+Scale is pure Tailwind (`text-xs`/`sm`/`base`/`lg`/`xl`/`2xl`/`4xl`/`5xl`). No custom type ramp. H1 in header scales `text-2xl sm:text-4xl md:text-5xl`.
+
+---
+
+## Component conventions
+
+**Emoji prefix on buttons.** Interactive controls in the toolbar lead with a single emoji to signal function at a glance:
+
+| Control         | Glyph  |
+| --------------- | ------ |
+| Filters toggle  | 🎛️     |
+| List view       | 📋     |
+| Map view        | 🗺️     |
+| Open now chip   | ☀️ / ⛅ / 🌧️ / ❄️ / 🌫️ / ⏳ / ⏰ (weather-driven) |
+
+Keep this convention for any new toolbar control — it's the main visual personality of the header.
+
+**Touch targets.** Controls that can be tapped on mobile use `min-h-[44px]` (Apple HIG). Toolbar buttons currently inherit enough padding; OpenNowChip enforces it explicitly — do the same for any new chip.
+
+**Focus.** Active focus ring is orange: `focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:ring-offset-2 focus-visible:outline-none`. Use this pattern on all new interactive elements, not the browser default.
+
+**Button shape.** `rounded-lg border-2` for primary action chips, `rounded` (4px) for smaller tertiary buttons and tags. Don't introduce a third radius without a reason.
+
+**Card shape.** `rounded-lg border-2 border-[#e2d9c8]` + white bg + hover-orange border + hover-lg shadow. Any new card-like surface should follow this pattern.
+
+---
+
+## Accessibility baseline
+
+- Contrast: navy-on-white, white-on-navy, orange-on-white all pass WCAG AA at the sizes used. Orange-on-cream (`#ed8936` on `#f5f0e6`) is borderline — keep it for accents only, never for body copy.
+- `aria-pressed` for toggle buttons (OpenNowChip pattern).
+- `aria-label` where the visible text is emoji-heavy or ambiguous.
+- Keyboard nav: every interactive element is tab-reachable, focus ring must remain visible.
+
+---
+
+## Design debt
+
+- **CSS custom properties in `style.css` are unused.** Components inline the same hex values in Tailwind bracket classes. Consequence: renaming a brand colour today requires editing ~7 component files instead of one variable.
+  - Options:
+    1. Migrate components to `bg-[var(--color-primary)]` — works but keeps the dual source of truth.
+    2. Move to Tailwind 4 `@theme` block in `style.css` — registers real design tokens so classes like `bg-primary` / `text-accent` work natively. Recommended.
+  - Scope: ~30 min, touches every component but only via find-and-replace.
+- **Hues outside the seven named vars** (navy-hover, navy-track, cream-deep, warm-border, cool-border, cream-surface, orange-hover, ink, body-muted, placeholder) need names before we can promote to tokens — hence this doc.
+- **No dark mode.** Cream-first palette doesn't currently map to a dark counterpart. Defer until there's a user ask.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,46 @@
+# TODOs
+
+## Weekend 1: Open Now + Weather-aware filter chip ✅ Shipped
+
+- [x] Vitest installed, `"test": "vitest"` script, `tests/` dir
+- [x] `src/utils/hoursBasic.ts` — parses `openingHours`, normalizes Unicode dashes (`[–—−] → -`), exports `parseOpeningHours()` + `isOpen(schedule, date)`
+- [x] `tests/hoursBasic.test.ts` — 18 tests: hyphen/en-dash/mixed, empty, closed days, overnight, week-wrap, real spaces.json samples
+- [x] `src/utils/weather.ts` — open-meteo fetch for Leuven, sessionStorage 30-min cache, `useWeather()` singleton composable, never throws
+- [x] `src/utils/weatherEmoji.ts` — condition + temp → ☀️/⛅/🌧️/❄️/🌫️/⏳/⏰
+- [x] `src/components/OpenNowChip.vue` — `<button aria-pressed>` with loading/failed/active/focus states, `min-h-[44px]` touch target
+- [x] `IFilterState` extended with `openNow: boolean`
+- [x] App.vue: chip mounted in toolbar next to Filters/View toggle, URL syncs `?openNow=1`, wraps on mobile
+- [x] Empty state: context-aware copy when `openNow` active with 0 matches (generic "nothing open" vs "nothing open + other filters")
+
+## Descoped from original plan
+
+- [ ] ~~`weatherFit: boolean` filter + weather-appropriate sort~~ — shipped as **emoji-only aliveness signal in chip label**. Revisit if users ask for it. If you bring it back: add a second boolean to IFilterState, rank spaces by `indoor vs outdoor` metadata (which doesn't exist in spaces.json yet — would require schema extension).
+
+## Manual QA — confirm before closing
+
+- [ ] Toggle chip on desktop; verify count changes and URL gains `?openNow=1`
+- [ ] Reload with `?openNow=1` — chip renders active
+- [ ] 375px mobile (Safari/Chrome devtools): toolbar wraps cleanly, no horizontal scroll
+- [ ] Keyboard: Tab to chip, Space/Enter toggles, focus ring visible
+- [ ] VoiceOver / TalkBack: chip announces "Open now, pressed/not pressed" with weather context
+- [ ] Empty-state copy shown when Leuven is quiet (e.g., open devtools, mock `Date` to 03:00 Mon)
+- [ ] Weather failure: throttle network to offline in devtools, hard refresh — chip falls back to plain "Open now" label (no weather)
+- [ ] Weather cache: toggle chip multiple times in a session — Network tab shows only one `api.open-meteo.com` request
+
+## Design debt (not blocking ship)
+
+- [ ] Extract implicit palette into `DESIGN.md` (post-ship polish)
+  - **Why:** palette lives only in Tailwind hex values across 7 components now; next design change will scatter further
+  - **Context:** navy `#1a365d`, orange `#ed8936`, cream `#f5f0e6`, warm bg `#fffaf0`, display font on h1/h2, emoji prefix convention on buttons
+  - **Depends on:** nothing; ~15 min
+
+## Explicitly not doing (yet)
+
+- ~~Three flip cards / TodayView~~
+- ~~LLM blurbs (Groq / templates)~~
+- ~~Ask-a-Friend chat~~
+- ~~Fuse.js, SunCalc, novelty cache~~
+- ~~`/` vs `/all` routing split~~
+- ~~Two separate chips (open + weather)~~ — one compound chip instead
+
+Revisit flip cards only after shipping the chip and seeing whether it feels alive.

--- a/TODOS.md
+++ b/TODOS.md
@@ -29,10 +29,8 @@
 
 ## Design debt (not blocking ship)
 
-- [ ] Extract implicit palette into `DESIGN.md` (post-ship polish)
-  - **Why:** palette lives only in Tailwind hex values across 7 components now; next design change will scatter further
-  - **Context:** navy `#1a365d`, orange `#ed8936`, cream `#f5f0e6`, warm bg `#fffaf0`, display font on h1/h2, emoji prefix convention on buttons
-  - **Depends on:** nothing; ~15 min
+- [x] Extract implicit palette into `DESIGN.md` — shipped. Doc captures 22 named hues, typography, component conventions, a11y baseline.
+- [ ] Migrate components from `bg-[#hex]` to Tailwind 4 `@theme` tokens (`bg-primary`, `text-accent`, etc.) — see DESIGN.md "Design debt" section. ~30 min, touches ~7 files via find-and-replace.
 
 ## Explicitly not doing (yet)
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -30,7 +30,10 @@
 ## Design debt (not blocking ship)
 
 - [x] Extract implicit palette into `DESIGN.md` — shipped. Doc captures 22 named hues, typography, component conventions, a11y baseline.
+- [x] 7-pass design-system review of `DESIGN.md` — shipped. Added TOC + "How to use", Layout & responsive section (breakpoints, container, grids, spacing), iconography policy, deviation rubric, full state/variant tables, three-token motion system, explicit contrast pairs, screen-reader patterns, Open questions section. Final rating: 8.5/10 avg across 7 passes.
 - [ ] Migrate components from `bg-[#hex]` to Tailwind 4 `@theme` tokens (`bg-primary`, `text-accent`, etc.) — see DESIGN.md "Design debt" section. ~30 min, touches ~7 files via find-and-replace.
+- [ ] **Apply focus-ring rule uniformly.** `FilterBar.vue` selects + sort buttons lack the prescribed `focus-visible:ring-2 focus-visible:ring-[#ed8936]` pattern. ~15 min. See DESIGN.md Design debt.
+- [ ] **Add `motion-reduce:transition-none` to motion tokens.** No current `prefers-reduced-motion` handling. ~10 min. Low priority while transitions stay subtle.
 
 ## Explicitly not doing (yet)
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "coworking",
       "dependencies": {
         "@vue-leaflet/vue-leaflet": "^0.10.1",
+        "@vueuse/core": "^14.1.0",
         "leaflet": "^1.9.4",
         "vue": "^3.5.24",
         "vue-tippy": "^6.7.1",
@@ -15,9 +17,12 @@
         "@types/node": "^24.10.1",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/tsconfig": "^0.8.1",
+        "prettier": "^3.8.0",
+        "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
-        "vite": "^7.2.4",
+        "vite": "^7.3.2",
+        "vitest": "^4.1.5",
         "vue-tsc": "^3.1.4",
       },
     },
@@ -147,6 +152,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.55.1", "", { "os": "win32", "cpu": "x64" }, "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.18", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.18", "@tailwindcss/oxide-darwin-arm64": "4.1.18", "@tailwindcss/oxide-darwin-x64": "4.1.18", "@tailwindcss/oxide-freebsd-x64": "4.1.18", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18", "@tailwindcss/oxide-linux-arm64-musl": "4.1.18", "@tailwindcss/oxide-linux-x64-gnu": "4.1.18", "@tailwindcss/oxide-linux-x64-musl": "4.1.18", "@tailwindcss/oxide-wasm32-wasi": "4.1.18", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18", "@tailwindcss/oxide-win32-x64-msvc": "4.1.18" } }, "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A=="],
@@ -177,6 +184,10 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
@@ -185,7 +196,23 @@
 
     "@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.53" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "vue": "^3.2.25" } }, "sha512-TlGPkLFLVOY3T7fZrwdvKpjprR3s4fxRln0ORDo1VQ7HHyxJwTlrjKU3kpVWTlaAjIEuCTokmjkZnr8Tpc925w=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
     "@volar/language-core": ["@volar/language-core@2.4.27", "", { "dependencies": { "@volar/source-map": "2.4.27" } }, "sha512-DjmjBWZ4tJKxfNC1F6HyYERNHPYS7L7OPFyCrestykNdUZMFYzI9WTyvwPcaNaHlrEUwESHYsfEw3isInncZxQ=="],
 
@@ -217,7 +244,19 @@
 
     "@vue/tsconfig": ["@vue/tsconfig@0.8.1", "", { "peerDependencies": { "typescript": "5.x", "vue": "^3.4.0" }, "optionalPeers": ["typescript", "vue"] }, "sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g=="],
 
+    "@vueuse/core": ["@vueuse/core@14.2.1", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "14.2.1", "@vueuse/shared": "14.2.1" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ=="],
+
+    "@vueuse/metadata": ["@vueuse/metadata@14.2.1", "", {}, "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw=="],
+
+    "@vueuse/shared": ["@vueuse/shared@14.2.1", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw=="],
+
     "alien-signals": ["alien-signals@3.1.2", "", {}, "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -227,9 +266,13 @@
 
     "entities": ["entities@7.0.0", "", {}, "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ=="],
 
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -271,7 +314,11 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -279,15 +326,31 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.7.2", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA=="],
+
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tippy.js": ["tippy.js@6.3.7", "", { "dependencies": { "@popperjs/core": "^2.9.0" } }, "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ=="],
 
@@ -295,7 +358,9 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
@@ -304,6 +369,8 @@
     "vue-tippy": ["vue-tippy@6.7.1", "", { "dependencies": { "tippy.js": "^6.3.7" }, "peerDependencies": { "vue": "^3.2.0" } }, "sha512-gdHbBV5/Vc8gH87hQHLA7TN1K4BlLco3MAPrTb70ZYGXxx+55rAU4a4mt0fIoP+gB3etu1khUZ6c29Br1n0CiA=="],
 
     "vue-tsc": ["vue-tsc@3.2.2", "", { "dependencies": { "@volar/typescript": "2.4.27", "@vue/language-core": "3.2.2" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-r9YSia/VgGwmbbfC06hDdAatH634XJ9nVl6Zrnz1iK4ucp8Wu78kawplXnIDa3MSu1XdQQePTHLXYwPDWn+nyQ=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -316,5 +383,9 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "bun run validate && vue-tsc -b && vite build",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{ts,vue,css}\" \"scripts/**/*.ts\"",
-    "format:check": "prettier --check \"src/**/*.{ts,vue,css}\" \"scripts/**/*.ts\""
+    "format:check": "prettier --check \"src/**/*.{ts,vue,css}\" \"scripts/**/*.ts\"",
+    "test": "vitest"
   },
   "dependencies": {
     "@vue-leaflet/vue-leaflet": "^0.10.1",
@@ -29,6 +30,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "vite": "^7.3.2",
+    "vitest": "^4.1.5",
     "vue-tsc": "^3.1.4"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,9 +49,10 @@ watch(
     } else {
       delete urlParams.openNow
     }
-    const selectKeys = Object.keys(DEFAULT_FILTERS).filter(
-      (k) => k !== 'openNow',
-    ) as Exclude<keyof IFilterState, 'openNow'>[]
+    const selectKeys = Object.keys(DEFAULT_FILTERS).filter((k) => k !== 'openNow') as Exclude<
+      keyof IFilterState,
+      'openNow'
+    >[]
     for (const key of selectKeys) {
       if (newFilters[key] !== 'all') {
         urlParams[key] = newFilters[key]
@@ -91,10 +92,12 @@ const filteredSpaces = computed(() => {
       (activeFilters.noiseLevel === 'all' || space.noiseLevel === activeFilters.noiseLevel) &&
       (activeFilters.wifiSpeed === 'all' || space.wifiSpeed === activeFilters.wifiSpeed) &&
       (activeFilters.hasAC === 'all' || space.hasAC === activeFilters.hasAC) &&
-      (activeFilters.foodAvailability === 'all' || space.foodAndDrinkAvailability === activeFilters.foodAvailability) &&
+      (activeFilters.foodAvailability === 'all' ||
+        space.foodAndDrinkAvailability === activeFilters.foodAvailability) &&
       (activeFilters.seatingType === 'all' || space.seatingType === activeFilters.seatingType) &&
       (activeFilters.hasOutlets === 'all' || space.hasOutlets === activeFilters.hasOutlets) &&
-      (activeFilters.verified === 'all' || (activeFilters.verified === 'verified' ? space.verified : !space.verified))
+      (activeFilters.verified === 'all' ||
+        (activeFilters.verified === 'verified' ? space.verified : !space.verified))
     )
   })
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,8 @@ import FilterBar from './components/FilterBar.vue'
 import SpaceList from './components/SpaceList.vue'
 import MapView from './components/MapView.vue'
 import VisitProgress from './components/VisitProgress.vue'
+import OpenNowChip from './components/OpenNowChip.vue'
+import { parseOpeningHours, isOpen } from './utils/hoursBasic'
 import spacesData from './data/spaces.json'
 
 const spaces = spacesData as ICoworkingSpace[]
@@ -19,6 +21,7 @@ const DEFAULT_FILTERS: IFilterState = {
   seatingType: 'all',
   hasOutlets: 'all',
   verified: 'all',
+  openNow: false,
 }
 
 // URL params and filter states
@@ -34,14 +37,22 @@ const filters = ref<IFilterState>({
     (urlParams.seatingType as IFilterState['seatingType']) || DEFAULT_FILTERS.seatingType,
   hasOutlets: (urlParams.hasOutlets as IFilterState['hasOutlets']) || DEFAULT_FILTERS.hasOutlets,
   verified: (urlParams.verified as IFilterState['verified']) || DEFAULT_FILTERS.verified,
+  openNow: urlParams.openNow === '1',
 })
 
 // Sync filters to URL
 watch(
   filters,
   (newFilters) => {
-    const filterKeys = Object.keys(DEFAULT_FILTERS) as (keyof IFilterState)[]
-    for (const key of filterKeys) {
+    if (newFilters.openNow) {
+      urlParams.openNow = '1'
+    } else {
+      delete urlParams.openNow
+    }
+    const selectKeys = Object.keys(DEFAULT_FILTERS).filter(
+      (k) => k !== 'openNow',
+    ) as Exclude<keyof IFilterState, 'openNow'>[]
+    for (const key of selectKeys) {
       if (newFilters[key] !== 'all') {
         urlParams[key] = newFilters[key]
       } else {
@@ -63,12 +74,18 @@ const viewMode = ref<ViewMode>('list')
 const showFilters = ref(false)
 
 const activeFilterCount = computed(() => {
-  return Object.values(filters.value).filter((v) => v !== 'all').length
+  const { openNow: _ignored, ...rest } = filters.value
+  return Object.values(rest).filter((v) => v !== 'all').length
 })
 
 const filteredSpaces = computed(() => {
+  const now = new Date()
   return spaces.filter((space) => {
     const activeFilters = filters.value
+
+    if (activeFilters.openNow) {
+      if (isOpen(parseOpeningHours(space.openingHours), now) !== true) return false
+    }
 
     return (
       (activeFilters.noiseLevel === 'all' || space.noiseLevel === activeFilters.noiseLevel) &&
@@ -81,6 +98,10 @@ const filteredSpaces = computed(() => {
     )
   })
 })
+
+function toggleOpenNow() {
+  filters.value = { ...filters.value, openNow: !filters.value.openNow }
+}
 </script>
 
 <template>
@@ -107,12 +128,15 @@ const filteredSpaces = computed(() => {
     <!-- Main Content -->
     <main class="mx-auto max-w-6xl px-6 py-8">
       <!-- Toolbar: Space count, Filter toggle, View mode -->
-      <div class="mb-4 flex items-center justify-between">
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-y-3">
         <p class="m-0 text-sm text-[#718096]">
           Showing {{ filteredSpaces.length }} of {{ spaces.length }} spaces
         </p>
 
-        <div class="flex items-center gap-3">
+        <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+          <!-- Open now chip -->
+          <OpenNowChip :active="filters.openNow" @toggle="toggleOpenNow" />
+
           <!-- Filter Toggle -->
           <button
             class="flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors"

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -62,11 +62,13 @@ function resetFilters() {
     seatingType: 'all',
     hasOutlets: 'all',
     verified: 'all',
+    openNow: props.filters.openNow,
   })
 }
 
 const hasActiveFilters = computed(() => {
-  return Object.values(props.filters).some((v) => v !== 'all')
+  const { openNow: _ignored, ...rest } = props.filters
+  return Object.values(rest).some((v) => v !== 'all')
 })
 
 const sortOptions: { field: SortField; label: string }[] = [

--- a/src/components/OpenNowChip.vue
+++ b/src/components/OpenNowChip.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useWeather } from '../utils/weather'
+import { weatherEmoji } from '../utils/weatherEmoji'
+
+interface Props {
+  active: boolean
+}
+
+defineProps<Props>()
+const emit = defineEmits<{ toggle: [] }>()
+
+const { weather, loading, failed } = useWeather()
+
+const emoji = computed(() => weatherEmoji(weather.value, loading.value))
+
+const label = computed(() => {
+  if (loading.value) return 'Open now'
+  if (failed.value || !weather.value) return 'Open now'
+  return `Open now · ${weather.value.tempC}°C`
+})
+
+const ariaLabel = computed(() => {
+  if (loading.value) return 'Open now, weather loading'
+  if (failed.value || !weather.value) return 'Open now'
+  return `Open now, currently ${weather.value.tempC} degrees ${weather.value.condition}`
+})
+
+const title = computed(() =>
+  failed.value
+    ? 'Show only spaces open based on today’s hours.'
+    : 'Show only spaces open based on today’s hours. Weather-aware label.',
+)
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-pressed="active"
+    :aria-label="ariaLabel"
+    :title="title"
+    :class="[
+      'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors',
+      'focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:ring-offset-2 focus-visible:outline-none',
+      active
+        ? 'border-[#1a365d] bg-[#1a365d] text-white hover:bg-[#15284a]'
+        : 'border-[#1a365d] bg-white text-[#1a365d] hover:bg-[#f5f0e6]',
+      loading && 'cursor-wait opacity-70',
+    ]"
+    @click="emit('toggle')"
+  >
+    <span aria-hidden="true">{{ emoji }}</span>
+    <span>{{ label }}</span>
+  </button>
+</template>

--- a/src/components/SpaceList.vue
+++ b/src/components/SpaceList.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import type { ICoworkingSpace, IFilterState, ISortState } from '../types/space'
 import SpaceCard from './SpaceCard.vue'
 import { slugify } from '../utils/slug'
+import { parseOpeningHours, isOpen } from '../utils/hoursBasic'
 
 interface Props {
   spaces: ICoworkingSpace[]
@@ -14,6 +15,20 @@ const props = defineProps<Props>()
 
 const WIFI_SPEED_ORDER = { unknown: 0, slow: 1, medium: 2, fast: 3 }
 const NOISE_LEVEL_ORDER = { quiet: 0, medium: 1, loud: 2 }
+
+const isOnlyOpenNowActive = computed(() => {
+  const f = props.filters
+  if (!f.openNow) return false
+  return (
+    f.noiseLevel === 'all' &&
+    f.wifiSpeed === 'all' &&
+    f.hasAC === 'all' &&
+    f.foodAvailability === 'all' &&
+    f.seatingType === 'all' &&
+    f.hasOutlets === 'all' &&
+    f.verified === 'all'
+  )
+})
 
 const filteredAndSortedSpaces = computed(() => {
   let result = [...props.spaces]
@@ -43,6 +58,10 @@ const filteredAndSortedSpaces = computed(() => {
   if (props.filters.verified === 'unverified') {
     result = result.filter((s) => !s.verified)
   }
+  if (props.filters.openNow) {
+    const now = new Date()
+    result = result.filter((s) => isOpen(parseOpeningHours(s.openingHours), now) === true)
+  }
 
   // Apply sorting
   const direction = props.sort.direction === 'asc' ? 1 : -1
@@ -71,8 +90,23 @@ const filteredAndSortedSpaces = computed(() => {
       v-if="filteredAndSortedSpaces.length === 0"
       class="rounded-lg border-2 border-dashed border-[#cbd5e0] bg-[#f5f0e6] px-6 py-12 text-center"
     >
-      <p class="m-0 mb-2 text-lg text-[#718096]">No spaces match your filters</p>
-      <p class="m-0 text-sm text-[#a0aec0]">Try adjusting your filter criteria</p>
+      <template v-if="isOnlyOpenNowActive">
+        <p class="m-0 mb-2 text-lg text-[#718096]">Nothing open right now</p>
+        <p class="m-0 text-sm text-[#a0aec0]">
+          Leuven is quiet at this hour. Try turning off <strong>Open now</strong>, or check back
+          later.
+        </p>
+      </template>
+      <template v-else-if="props.filters.openNow">
+        <p class="m-0 mb-2 text-lg text-[#718096]">No open spaces match your filters</p>
+        <p class="m-0 text-sm text-[#a0aec0]">
+          Try removing <strong>Open now</strong> or loosening another filter.
+        </p>
+      </template>
+      <template v-else>
+        <p class="m-0 mb-2 text-lg text-[#718096]">No spaces match your filters</p>
+        <p class="m-0 text-sm text-[#a0aec0]">Try adjusting your filter criteria</p>
+      </template>
     </div>
 
     <!-- Space grid -->

--- a/src/components/VisitProgress.vue
+++ b/src/components/VisitProgress.vue
@@ -64,7 +64,9 @@ async function copyShareLink() {
                   :class="{ 'text-green-400 hover:text-green-400': copyStatus === 'copied' }"
                   @click="copyShareLink"
                 >
-                  {{ copyStatus === 'copied' ? 'copied link to clipboard!' : 'copy my progress link' }}
+                  {{
+                    copyStatus === 'copied' ? 'copied link to clipboard!' : 'copy my progress link'
+                  }}
                 </button>
               </p>
             </div>

--- a/src/types/space.ts
+++ b/src/types/space.ts
@@ -61,6 +61,7 @@ export interface IFilterState {
   seatingType: SeatingType | 'all'
   hasOutlets: OutletAvailability | 'all'
   verified: VerifiedFilter
+  openNow: boolean
 }
 
 export type SortField = 'name' | 'wifiSpeed' | 'noiseLevel'

--- a/src/utils/hoursBasic.ts
+++ b/src/utils/hoursBasic.ts
@@ -1,0 +1,110 @@
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+const DAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+}
+
+export interface TimeRange {
+  start: number
+  end: number
+}
+
+export type DaySchedule = Record<number, TimeRange[]>
+
+function normalizeDashes(s: string): string {
+  return s.replace(/[–—−]/g, '-')
+}
+
+function parseHHMM(s: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim())
+  if (!m || m[1] === undefined || m[2] === undefined) return null
+  const h = parseInt(m[1], 10)
+  const mm = parseInt(m[2], 10)
+  if (h < 0 || h > 24 || mm < 0 || mm >= 60) return null
+  return h * 60 + mm
+}
+
+function parseDayList(daysPart: string): number[] | null {
+  const parts = daysPart.split('-').map((s) => s.trim())
+  if (parts.length === 1) {
+    const key = parts[0]
+    if (!key) return null
+    const d = DAY_INDEX[key]
+    return d === undefined ? null : [d]
+  }
+  if (parts.length !== 2) return null
+  const keyA = parts[0]
+  const keyB = parts[1]
+  if (!keyA || !keyB) return null
+  const a = DAY_INDEX[keyA]
+  const b = DAY_INDEX[keyB]
+  if (a === undefined || b === undefined) return null
+  const result: number[] = []
+  let i = a
+  while (true) {
+    result.push(i)
+    if (i === b) break
+    i = (i + 1) % 7
+    if (result.length > 7) return null
+  }
+  return result
+}
+
+function emptySchedule(): DaySchedule {
+  return { 0: [], 1: [], 2: [], 3: [], 4: [], 5: [], 6: [] }
+}
+
+export function parseOpeningHours(raw: string): DaySchedule | null {
+  if (!raw || !raw.trim()) return null
+  const normalized = normalizeDashes(raw)
+  const schedule = emptySchedule()
+
+  for (const segment of normalized
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    const firstSpace = segment.indexOf(' ')
+    if (firstSpace === -1) return null
+    const daysPart = segment.slice(0, firstSpace)
+    const rest = segment.slice(firstSpace + 1).trim()
+    const days = parseDayList(daysPart)
+    if (!days) return null
+
+    if (rest.toLowerCase() === 'closed') continue
+
+    const timeMatch = /^(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})$/.exec(rest)
+    if (!timeMatch || timeMatch[1] === undefined || timeMatch[2] === undefined) return null
+    const start = parseHHMM(timeMatch[1])
+    const end = parseHHMM(timeMatch[2])
+    if (start === null || end === null) return null
+    const effectiveEnd = end === 0 ? 24 * 60 : end
+    const isOvernight = effectiveEnd <= start
+    const clampedEnd = isOvernight ? 24 * 60 : effectiveEnd
+
+    for (const d of days) {
+      const dayRanges = schedule[d]
+      if (dayRanges) dayRanges.push({ start, end: clampedEnd })
+    }
+  }
+
+  return schedule
+}
+
+export function isOpen(schedule: DaySchedule | null, at: Date): boolean | null {
+  if (!schedule) return null
+  const day = at.getDay()
+  const minutes = at.getHours() * 60 + at.getMinutes()
+  const ranges = schedule[day]
+  if (!ranges || ranges.length === 0) return false
+  for (const r of ranges) {
+    if (minutes >= r.start && minutes < r.end) return true
+  }
+  return false
+}
+
+export const __TEST_ONLY__ = { DAYS, DAY_INDEX, normalizeDashes, parseHHMM, parseDayList }

--- a/src/utils/weather.ts
+++ b/src/utils/weather.ts
@@ -1,0 +1,101 @@
+import { ref, type Ref } from 'vue'
+
+export type WeatherCondition = 'sunny' | 'cloudy' | 'rainy' | 'snowy' | 'foggy' | 'unknown'
+
+export interface Weather {
+  tempC: number
+  condition: WeatherCondition
+  weatherCode: number
+  fetchedAt: number
+}
+
+const CACHE_KEY = 'weather-leuven-v1'
+const TTL_MS = 30 * 60 * 1000
+const LEUVEN = { lat: 50.8798, lng: 4.7005 }
+
+function classifyWmo(code: number): WeatherCondition {
+  if (code === 0 || code === 1) return 'sunny'
+  if (code === 2 || code === 3) return 'cloudy'
+  if (code === 45 || code === 48) return 'foggy'
+  if ((code >= 51 && code <= 67) || (code >= 80 && code <= 82) || code >= 95) return 'rainy'
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return 'snowy'
+  return 'unknown'
+}
+
+function readCache(): Weather | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Weather
+    if (Date.now() - parsed.fetchedAt > TTL_MS) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeCache(w: Weather) {
+  try {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(w))
+  } catch {
+    // storage disabled; ignore
+  }
+}
+
+async function fetchWeather(): Promise<Weather | null> {
+  try {
+    const url =
+      `https://api.open-meteo.com/v1/forecast` +
+      `?latitude=${LEUVEN.lat}&longitude=${LEUVEN.lng}` +
+      `&current=temperature_2m,weather_code&timezone=Europe/Brussels`
+    const res = await fetch(url)
+    if (!res.ok) return null
+    const data = await res.json()
+    const t = data?.current?.temperature_2m
+    const c = data?.current?.weather_code
+    if (typeof t !== 'number' || typeof c !== 'number') return null
+    return {
+      tempC: Math.round(t),
+      condition: classifyWmo(c),
+      weatherCode: c,
+      fetchedAt: Date.now(),
+    }
+  } catch {
+    return null
+  }
+}
+
+interface UseWeatherResult {
+  weather: Ref<Weather | null>
+  loading: Ref<boolean>
+  failed: Ref<boolean>
+}
+
+let sharedState: UseWeatherResult | null = null
+
+export function useWeather(): UseWeatherResult {
+  if (sharedState) return sharedState
+
+  const weather = ref<Weather | null>(null)
+  const loading = ref(true)
+  const failed = ref(false)
+
+  const cached = readCache()
+  if (cached) {
+    weather.value = cached
+    loading.value = false
+  } else {
+    fetchWeather().then((w) => {
+      if (w) {
+        weather.value = w
+        writeCache(w)
+      } else {
+        failed.value = true
+      }
+      loading.value = false
+    })
+  }
+
+  sharedState = { weather, loading, failed }
+  return sharedState
+}

--- a/src/utils/weatherEmoji.ts
+++ b/src/utils/weatherEmoji.ts
@@ -1,0 +1,12 @@
+import type { Weather } from './weather'
+
+export function weatherEmoji(w: Weather | null, loading = false): string {
+  if (loading) return '⏳'
+  if (!w) return '⏰'
+  if (w.condition === 'snowy' || w.tempC < 5) return '❄️'
+  if (w.condition === 'rainy') return '🌧️'
+  if (w.condition === 'foggy') return '🌫️'
+  if (w.condition === 'cloudy') return '⛅'
+  if (w.condition === 'sunny' && w.tempC >= 15) return '☀️'
+  return '⛅'
+}

--- a/tests/hoursBasic.test.ts
+++ b/tests/hoursBasic.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { parseOpeningHours, isOpen } from '../src/utils/hoursBasic'
+
+const DOW = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 } as const
+
+function at(dow: keyof typeof DOW, hh: number, mm = 0): Date {
+  const d = new Date('2026-04-19T00:00:00Z')
+  const current = d.getUTCDay()
+  const target = DOW[dow]
+  d.setUTCDate(d.getUTCDate() + ((target - current + 7) % 7))
+  d.setHours(hh, mm, 0, 0)
+  return d
+}
+
+describe('parseOpeningHours — dash normalization', () => {
+  it('parses hyphen (U+002D) day ranges', () => {
+    const s = parseOpeningHours('Mon-Fri 09:00-18:00')
+    expect(s).not.toBeNull()
+    expect(s![DOW.Mon]).toEqual([{ start: 540, end: 1080 }])
+    expect(s![DOW.Fri]).toEqual([{ start: 540, end: 1080 }])
+  })
+
+  it('parses en-dash (U+2013) day ranges identically', () => {
+    const s = parseOpeningHours('Mon\u2013Fri 09:00\u201318:00')
+    expect(s).not.toBeNull()
+    expect(s![DOW.Mon]).toEqual([{ start: 540, end: 1080 }])
+    expect(s![DOW.Fri]).toEqual([{ start: 540, end: 1080 }])
+  })
+
+  it('treats mixed dash styles in one string correctly', () => {
+    const s = parseOpeningHours('Mon-Fri 09:00\u201318:00, Sat\u2013Sun 10:00-17:00')
+    expect(s).not.toBeNull()
+    expect(s![DOW.Mon]).toEqual([{ start: 540, end: 1080 }])
+    expect(s![DOW.Sat]).toEqual([{ start: 600, end: 1020 }])
+    expect(s![DOW.Sun]).toEqual([{ start: 600, end: 1020 }])
+  })
+})
+
+describe('parseOpeningHours — empty/invalid', () => {
+  it('returns null for empty string', () => {
+    expect(parseOpeningHours('')).toBeNull()
+  })
+  it('returns null for whitespace-only', () => {
+    expect(parseOpeningHours('   ')).toBeNull()
+  })
+  it('returns null for garbage', () => {
+    expect(parseOpeningHours('sometimes open')).toBeNull()
+  })
+})
+
+describe('parseOpeningHours — closed days', () => {
+  it('excludes days marked closed', () => {
+    const s = parseOpeningHours('Mon-Thu 09:00-17:00, Fri 09:00-15:00, Sat-Sun closed')
+    expect(s).not.toBeNull()
+    expect(s![DOW.Mon]).toEqual([{ start: 540, end: 1020 }])
+    expect(s![DOW.Fri]).toEqual([{ start: 540, end: 900 }])
+    expect(s![DOW.Sat]).toEqual([])
+    expect(s![DOW.Sun]).toEqual([])
+  })
+})
+
+describe('parseOpeningHours — day wrapping', () => {
+  it('handles Sun-Mon (wraps through week)', () => {
+    const s = parseOpeningHours('Sun-Mon closed, Tue-Thu 11:00-18:00')
+    expect(s).not.toBeNull()
+    expect(s![DOW.Sun]).toEqual([])
+    expect(s![DOW.Mon]).toEqual([])
+    expect(s![DOW.Tue]).toEqual([{ start: 660, end: 1080 }])
+  })
+})
+
+describe('parseOpeningHours — midnight and overnight', () => {
+  it('treats 00:00 end as end-of-day (24:00)', () => {
+    const s = parseOpeningHours('Mon-Fri 10:00-00:00')
+    expect(s![DOW.Mon]).toEqual([{ start: 600, end: 1440 }])
+  })
+  it('treats overnight as closing at midnight of same day (W1 pragmatic)', () => {
+    const s = parseOpeningHours('Sat 13:00-03:00')
+    expect(s![DOW.Sat]).toEqual([{ start: 780, end: 1440 }])
+  })
+})
+
+describe('isOpen', () => {
+  const monFri9to18 = parseOpeningHours('Mon-Fri 09:00-18:00, Sat-Sun closed')
+
+  it('returns true during open hours', () => {
+    expect(isOpen(monFri9to18, at('Tue', 14, 20))).toBe(true)
+  })
+  it('returns false before opening', () => {
+    expect(isOpen(monFri9to18, at('Tue', 8, 59))).toBe(false)
+  })
+  it('returns false exactly at closing time (end is exclusive)', () => {
+    expect(isOpen(monFri9to18, at('Tue', 18, 0))).toBe(false)
+  })
+  it('returns false on closed day', () => {
+    expect(isOpen(monFri9to18, at('Sat', 14, 0))).toBe(false)
+  })
+  it('returns null when schedule is null (unknown hours)', () => {
+    expect(isOpen(null, at('Tue', 14, 0))).toBeNull()
+  })
+})
+
+describe('isOpen — real spaces.json samples', () => {
+  it('M-Tribe: open Tue 14:20 (Mon-Fri 08:30-18:00)', () => {
+    const s = parseOpeningHours('Mon-Fri 08:30-18:00, Sat 08:30-18:00, Sun 09:00-17:00')
+    expect(isOpen(s, at('Tue', 14, 20))).toBe(true)
+  })
+  it('Stadsbibliotheek-style: closed Sunday', () => {
+    const s = parseOpeningHours('Mon\u2013Fri 09:00\u201318:00, Sat 10:00\u201318:00, Sun closed')
+    expect(isOpen(s, at('Sun', 11, 0))).toBe(false)
+  })
+  it('Bar Permeke-style: open Sat 13:00 (overnight range)', () => {
+    const s = parseOpeningHours('Mon-Fri 10:00-03:00, Sat 13:00-03:00, Sun 17:00-02:00')
+    expect(isOpen(s, at('Sat', 14, 0))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- **Open-now filter chip** — parses `openingHours` (with Unicode-dash normalization), fetches Leuven weather via open-meteo, renders a toggle chip in the toolbar with live weather emoji. URL syncs `?openNow=1`. Empty state copy adapts when the filter hides everything.
- **Design system doc (`DESIGN.md`)** — extracted the implicit 22-hue palette, typography, component recipes, states, motion, a11y, responsive rules, and open questions. Went through a 7-pass design-system review (avg 8.5/10).
- **Vitest wired up** with 18 tests covering opening-hours edge cases (en-dash, overnight, week-wrap, closed days, real `spaces.json` samples).

## Test plan

- [x] `npm test` — 18/18 passing
- [x] `npm run build` — type-check + production bundle green
- [x] `npm run format:check` — clean
- [ ] Toggle chip on desktop: count changes, URL gains `?openNow=1`
- [ ] Reload with `?openNow=1` — chip renders active
- [ ] 375px mobile: toolbar wraps cleanly, no horizontal scroll
- [ ] Keyboard: Tab → chip, Space/Enter toggles, focus ring visible
- [ ] VoiceOver: announces "Open now, pressed/not pressed" with weather context
- [ ] Weather failure (offline devtools): chip falls back to plain "Open now" label
- [ ] Weather cache: toggle multiple times → one `api.open-meteo.com` request per session

## Debt filed (not blocking)

- Migrate `bg-[#hex]` → Tailwind 4 `@theme` tokens (~30 min, ~7 files)
- Apply focus-ring rule uniformly (FilterBar selects + sort buttons)
- Add `motion-reduce:transition-none` to motion tokens