### PR TITLE
:sparkles: Today's picks \u2014 three rotating featured cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.gstack/

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ import SpaceList from './components/SpaceList.vue'
 import MapView from './components/MapView.vue'
 import VisitProgress from './components/VisitProgress.vue'
 import OpenNowChip from './components/OpenNowChip.vue'
+import TodayView from './components/TodayView.vue'
 import { parseOpeningHours, isOpen } from './utils/hoursBasic'
 import spacesData from './data/spaces.json'
 
@@ -130,6 +131,9 @@ function toggleOpenNow() {
 
     <!-- Main Content -->
     <main class="mx-auto max-w-6xl px-6 py-8">
+      <!-- Today's picks (list view only) -->
+      <TodayView v-if="viewMode === 'list'" :spaces="spaces" />
+
       <!-- Toolbar: Space count, Filter toggle, View mode -->
       <div class="mb-4 flex flex-wrap items-center justify-between gap-y-3">
         <p class="m-0 text-sm text-[#718096]">

--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -47,6 +47,7 @@ function toggle() {
       <!-- Front -->
       <div
         class="absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 border-[#e2d9c8] bg-white p-5 [backface-visibility:hidden] group-hover:border-[#ed8936]"
+        :aria-hidden="flipped"
       >
         <div>
           <p class="m-0 mb-2 text-xs font-semibold tracking-wide text-[#ed8936] uppercase">
@@ -81,6 +82,7 @@ function toggle() {
       <!-- Back -->
       <div
         class="absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 border-[#ed8936] bg-[#fffaf0] p-5 [backface-visibility:hidden]"
+        :aria-hidden="!flipped"
       >
         <h3 class="font-display m-0 mb-2 text-lg font-bold text-[#1a365d]">
           {{ pick.space.name }}

--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { IFeaturedPick } from '../utils/featuredSpaces'
+import { NOISE_LEVEL_LABELS, WIFI_SPEED_LABELS, FOOD_LABELS } from '../types/space'
+
+interface Props {
+  pick: IFeaturedPick
+}
+
+const props = defineProps<Props>()
+const flipped = ref(false)
+
+const firstSentence = computed(() => {
+  const d = props.pick.space.description.trim()
+  const match = d.match(/^[^.!?]+[.!?]/)
+  return (match ? match[0] : d).trim()
+})
+
+const pills = computed(() => {
+  const s = props.pick.space
+  const out: string[] = []
+  out.push(NOISE_LEVEL_LABELS[s.noiseLevel])
+  out.push(`${WIFI_SPEED_LABELS[s.wifiSpeed]} WiFi`)
+  if (s.foodAndDrinkAvailability !== 'none') {
+    out.push(FOOD_LABELS[s.foodAndDrinkAvailability])
+  }
+  return out
+})
+
+function toggle() {
+  flipped.value = !flipped.value
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    class="group relative block h-64 w-full cursor-pointer rounded-lg text-left [perspective:1000px] focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:outline-none"
+    :aria-pressed="flipped"
+    :aria-label="`${pick.label}: ${pick.space.name} — click to ${flipped ? 'hide' : 'show'} details`"
+    @click="toggle"
+  >
+    <div
+      class="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d] motion-reduce:transition-none"
+      :class="flipped ? '[transform:rotateY(180deg)]' : ''"
+    >
+      <!-- Front -->
+      <div
+        class="absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 border-[#e2d9c8] bg-white p-5 [backface-visibility:hidden] group-hover:border-[#ed8936]"
+      >
+        <div>
+          <p class="m-0 mb-2 text-xs font-semibold tracking-wide text-[#ed8936] uppercase">
+            {{ pick.label }}
+          </p>
+          <h3 class="font-display m-0 mb-1 text-xl font-bold text-[#1a365d]">
+            {{ pick.space.name }}
+          </h3>
+          <p class="m-0 text-xs text-[#718096] italic">{{ pick.hook }}</p>
+        </div>
+
+        <div>
+          <p class="m-0 mb-3 line-clamp-3 text-sm text-[#4a5568]">
+            {{ firstSentence }}
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              v-for="pill in pills"
+              :key="pill"
+              class="rounded-full bg-[#f5f0e6] px-2 py-0.5 text-xs font-medium text-[#1a365d]"
+            >
+              {{ pill }}
+            </span>
+          </div>
+        </div>
+
+        <span aria-hidden="true" class="absolute right-3 bottom-3 text-xs text-[#a0aec0]">
+          tap to flip ↻
+        </span>
+      </div>
+
+      <!-- Back -->
+      <div
+        class="absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 border-[#ed8936] bg-[#fffaf0] p-5 [backface-visibility:hidden]"
+      >
+        <h3 class="font-display m-0 mb-2 text-lg font-bold text-[#1a365d]">
+          {{ pick.space.name }}
+        </h3>
+        <p class="m-0 mb-3 text-sm text-[#4a5568]">{{ pick.space.description }}</p>
+
+        <div v-if="pick.space.atmosphereNotes" class="mb-2">
+          <p class="m-0 text-xs font-semibold tracking-wide text-[#718096] uppercase">Atmosphere</p>
+          <p class="m-0 text-xs text-[#4a5568]">{{ pick.space.atmosphereNotes }}</p>
+        </div>
+
+        <div v-if="pick.space.seatingNotes">
+          <p class="m-0 text-xs font-semibold tracking-wide text-[#718096] uppercase">Seating</p>
+          <p class="m-0 text-xs text-[#4a5568]">{{ pick.space.seatingNotes }}</p>
+        </div>
+
+        <span aria-hidden="true" class="absolute right-3 bottom-3 text-xs text-[#a0aec0]">
+          tap to flip back ↺
+        </span>
+      </div>
+    </div>
+  </button>
+</template>

--- a/src/components/TodayView.vue
+++ b/src/components/TodayView.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { ICoworkingSpace } from '../types/space'
+import { getFeaturedSpaces } from '../utils/featuredSpaces'
+import FeaturedCard from './FeaturedCard.vue'
+
+interface Props {
+  spaces: ICoworkingSpace[]
+}
+
+const props = defineProps<Props>()
+
+const STORAGE_KEY = 'todayView.collapsed'
+const collapsed = ref(false)
+
+try {
+  collapsed.value = localStorage.getItem(STORAGE_KEY) === '1'
+} catch {
+  collapsed.value = false
+}
+
+watch(collapsed, (val) => {
+  try {
+    if (val) localStorage.setItem(STORAGE_KEY, '1')
+    else localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore storage failures
+  }
+})
+
+const picks = computed(() => getFeaturedSpaces(props.spaces))
+</script>
+
+<template>
+  <section v-if="picks.length > 0" class="mb-6" aria-label="Today's featured coworking spaces">
+    <div class="mb-3 flex items-center justify-between">
+      <h2 class="font-display m-0 text-lg font-bold text-[#1a365d] sm:text-xl">Today's picks</h2>
+      <button
+        type="button"
+        class="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-[#718096] transition-colors hover:text-[#1a365d] focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:outline-none"
+        :aria-expanded="!collapsed"
+        :aria-label="collapsed ? 'Show today\'s picks' : 'Hide today\'s picks'"
+        @click="collapsed = !collapsed"
+      >
+        <span>{{ collapsed ? 'Show' : 'Hide' }}</span>
+        <span
+          aria-hidden="true"
+          class="inline-block transition-transform"
+          :class="{ 'rotate-180': !collapsed }"
+        >
+          ▼
+        </span>
+      </button>
+    </div>
+
+    <div v-show="!collapsed" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <FeaturedCard v-for="pick in picks" :key="pick.slot" :pick="pick" />
+    </div>
+  </section>
+</template>

--- a/src/utils/featuredSpaces.ts
+++ b/src/utils/featuredSpaces.ts
@@ -1,0 +1,69 @@
+import type { ICoworkingSpace } from '../types/space'
+
+export type FeaturedSlot = 'quiet' | 'social' | 'discovery'
+
+export interface IFeaturedPick {
+  slot: FeaturedSlot
+  label: string
+  hook: string
+  space: ICoworkingSpace
+}
+
+const SLOT_META: Record<FeaturedSlot, { label: string; hook: string }> = {
+  quiet: { label: 'Quiet focus', hook: 'Deep-work mode' },
+  social: { label: 'Meet a friend', hook: 'Snacks & company' },
+  discovery: { label: "Today's discovery", hook: 'Somewhere new' },
+}
+
+export function dateKey(date: Date, timeZone = 'Europe/Brussels'): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date)
+}
+
+function hash(str: string): number {
+  let h = 5381
+  for (let i = 0; i < str.length; i++) {
+    h = (h << 5) + h + str.charCodeAt(i)
+  }
+  return h >>> 0
+}
+
+export function getFeaturedSpaces(
+  spaces: ICoworkingSpace[],
+  date: Date = new Date(),
+): IFeaturedPick[] {
+  const seed = hash(dateKey(date))
+  const picked = new Set<string>()
+
+  const pickFrom = (pool: ICoworkingSpace[], offset: number): ICoworkingSpace | null => {
+    const avail = pool.filter((s) => !picked.has(s.name))
+    const chosen = avail[(seed + offset) % avail.length]
+    if (!chosen) return null
+    picked.add(chosen.name)
+    return chosen
+  }
+
+  const verified = spaces.filter((s) => s.verified)
+  const quietPool = verified.filter((s) => s.noiseLevel === 'quiet')
+  const socialPool = verified.filter((s) => s.foodAndDrinkAvailability === 'full')
+
+  const slots: IFeaturedPick[] = []
+  const slotDefs: { slot: FeaturedSlot; pool: ICoworkingSpace[]; offset: number }[] = [
+    { slot: 'quiet', pool: quietPool.length ? quietPool : verified, offset: 0 },
+    { slot: 'social', pool: socialPool.length ? socialPool : verified, offset: 7 },
+    { slot: 'discovery', pool: verified, offset: 13 },
+  ]
+
+  for (const { slot, pool, offset } of slotDefs) {
+    const space = pickFrom(pool, offset)
+    if (space) {
+      slots.push({ slot, ...SLOT_META[slot], space })
+    }
+  }
+
+  return slots
+}

--- a/tests/featuredSpaces.test.ts
+++ b/tests/featuredSpaces.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { getFeaturedSpaces, dateKey } from '../src/utils/featuredSpaces'
+import type { ICoworkingSpace } from '../src/types/space'
+
+function mkSpace(overrides: Partial<ICoworkingSpace> & { name: string }): ICoworkingSpace {
+  return {
+    name: overrides.name,
+    address: '',
+    googleMapsUrl: '',
+    coordinates: { lat: 0, lng: 0 },
+    noiseLevel: 'medium',
+    wifiSpeed: 'medium',
+    hasAC: 'yes',
+    foodAndDrinkAvailability: 'light',
+    seatingType: 'mixed',
+    hasOutlets: 'some',
+    description: `Description of ${overrides.name}`,
+    openingHours: 'Mon-Sun 09:00-18:00',
+    atmosphereNotes: '',
+    wifiNotes: '',
+    climateNotes: '',
+    foodNotes: '',
+    drinkNotes: '',
+    seatingNotes: '',
+    outletNotes: '',
+    verified: true,
+    ...overrides,
+  }
+}
+
+const POOL: ICoworkingSpace[] = [
+  mkSpace({ name: 'Quiet-A', noiseLevel: 'quiet' }),
+  mkSpace({ name: 'Quiet-B', noiseLevel: 'quiet' }),
+  mkSpace({ name: 'Quiet-C', noiseLevel: 'quiet' }),
+  mkSpace({ name: 'Social-A', foodAndDrinkAvailability: 'full' }),
+  mkSpace({ name: 'Social-B', foodAndDrinkAvailability: 'full' }),
+  mkSpace({ name: 'Social-C', foodAndDrinkAvailability: 'full' }),
+  mkSpace({ name: 'Plain-A' }),
+  mkSpace({ name: 'Plain-B' }),
+  mkSpace({ name: 'Unverified', verified: false }),
+]
+
+describe('dateKey', () => {
+  it('returns ISO date string in Europe/Brussels timezone', () => {
+    const key = dateKey(new Date('2026-04-22T10:00:00Z'))
+    expect(key).toBe('2026-04-22')
+  })
+
+  it('crosses date boundary correctly for late-UTC / early-Brussels', () => {
+    // 23:30 UTC on April 22 = 01:30 Brussels on April 23 (CEST, +2)
+    const key = dateKey(new Date('2026-04-22T23:30:00Z'))
+    expect(key).toBe('2026-04-23')
+  })
+})
+
+describe('getFeaturedSpaces', () => {
+  it('returns three picks — one per slot', () => {
+    const picks = getFeaturedSpaces(POOL, new Date('2026-04-22T10:00:00Z'))
+    expect(picks).toHaveLength(3)
+    expect(picks.map((p) => p.slot)).toEqual(['quiet', 'social', 'discovery'])
+  })
+
+  it('is deterministic — same date returns the same three spaces', () => {
+    const a = getFeaturedSpaces(POOL, new Date('2026-04-22T10:00:00Z'))
+    const b = getFeaturedSpaces(POOL, new Date('2026-04-22T18:00:00Z'))
+    expect(a.map((p) => p.space.name)).toEqual(b.map((p) => p.space.name))
+  })
+
+  it('different dates generally produce different picks', () => {
+    const day1 = getFeaturedSpaces(POOL, new Date('2026-04-22T10:00:00Z'))
+    const day2 = getFeaturedSpaces(POOL, new Date('2026-04-23T10:00:00Z'))
+    const day3 = getFeaturedSpaces(POOL, new Date('2026-04-24T10:00:00Z'))
+    const allSame =
+      day1.map((p) => p.space.name).join() === day2.map((p) => p.space.name).join() &&
+      day2.map((p) => p.space.name).join() === day3.map((p) => p.space.name).join()
+    expect(allSame).toBe(false)
+  })
+
+  it('never picks the same space twice across slots', () => {
+    for (let day = 0; day < 30; day++) {
+      const date = new Date('2026-04-01T10:00:00Z')
+      date.setUTCDate(date.getUTCDate() + day)
+      const picks = getFeaturedSpaces(POOL, date)
+      const names = picks.map((p) => p.space.name)
+      expect(new Set(names).size).toBe(names.length)
+    }
+  })
+
+  it('excludes unverified spaces', () => {
+    for (let day = 0; day < 30; day++) {
+      const date = new Date('2026-04-01T10:00:00Z')
+      date.setUTCDate(date.getUTCDate() + day)
+      const picks = getFeaturedSpaces(POOL, date)
+      for (const p of picks) {
+        expect(p.space.verified).toBe(true)
+      }
+    }
+  })
+
+  it('quiet slot picks from the quiet pool when available', () => {
+    for (let day = 0; day < 14; day++) {
+      const date = new Date('2026-04-01T10:00:00Z')
+      date.setUTCDate(date.getUTCDate() + day)
+      const picks = getFeaturedSpaces(POOL, date)
+      const quiet = picks.find((p) => p.slot === 'quiet')
+      expect(quiet?.space.noiseLevel).toBe('quiet')
+    }
+  })
+
+  it('social slot picks from full-food pool when available', () => {
+    for (let day = 0; day < 14; day++) {
+      const date = new Date('2026-04-01T10:00:00Z')
+      date.setUTCDate(date.getUTCDate() + day)
+      const picks = getFeaturedSpaces(POOL, date)
+      const social = picks.find((p) => p.slot === 'social')
+      expect(social?.space.foodAndDrinkAvailability).toBe('full')
+    }
+  })
+
+  it('falls back to verified pool when a slot pool is empty', () => {
+    const noQuiet = POOL.filter((s) => s.noiseLevel !== 'quiet')
+    const picks = getFeaturedSpaces(noQuiet, new Date('2026-04-22T10:00:00Z'))
+    expect(picks).toHaveLength(3)
+    const quiet = picks.find((p) => p.slot === 'quiet')
+    expect(quiet).toBeDefined()
+    expect(quiet!.space.verified).toBe(true)
+  })
+
+  it('returns fewer picks gracefully when pool is tiny', () => {
+    const tiny = [mkSpace({ name: 'Only-A' }), mkSpace({ name: 'Only-B' })]
+    const picks = getFeaturedSpaces(tiny, new Date('2026-04-22T10:00:00Z'))
+    expect(picks.length).toBeLessThanOrEqual(2)
+    expect(new Set(picks.map((p) => p.space.name)).size).toBe(picks.length)
+  })
+
+  it('returns empty array when no verified spaces exist', () => {
+    const all = [mkSpace({ name: 'X', verified: false })]
+    const picks = getFeaturedSpaces(all, new Date('2026-04-22T10:00:00Z'))
+    expect(picks).toEqual([])
+  })
+
+  it('real spaces.json data: picks three stable featured spaces', async () => {
+    const mod = await import('../src/data/spaces.json')
+    const spaces = (mod.default ?? mod) as unknown as ICoworkingSpace[]
+    const picks = getFeaturedSpaces(spaces, new Date('2026-04-22T10:00:00Z'))
+    expect(picks).toHaveLength(3)
+    expect(new Set(picks.map((p) => p.space.name)).size).toBe(3)
+    for (const p of picks) expect(p.space.verified).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Three featured coworking spaces above the toolbar, seeded by today's date (Europe/Brussels), so every visitor sees the same picks on any given day — rotating at midnight.

Slots:
- **Quiet focus** — verified spaces with `noiseLevel=quiet`
- **Meet a friend** — verified spaces with `foodAndDrinkAvailability=full`
- **Today's discovery** — anything else from the verified pool

Falls back to the verified pool if a themed slot is empty, and never duplicates across slots.

Each card flips on click (3D `rotateY`) — front shows name, hook tagline, first sentence of description, and metadata pills; back shows the full description plus atmosphere + seating notes. Collapsible with localStorage persistence, list-view only.

Stacked on #9. Rebase onto main after #9 merges.

## QA

- [x] Ran `/qa` on localhost (desktop 1280×800 + mobile 375×812)
- [x] One a11y issue found + fixed in-session:
  - **ISSUE-001 (moderate):** both flip-card faces were in the accessibility tree at once (`backface-visibility: hidden` is visual-only). Fixed by toggling `aria-hidden` on each face reactively — `e03bb18`.
- Full report: `.gstack/qa-reports/qa-report-localhost-2026-04-22.md`

## Test plan

- [x] `npm test` — 31/31 green (13 new, covering determinism, dupes, empty-pool fallback, unverified exclusion, real-data smoke)
- [x] `npm run build` — type-check + bundle clean
- [x] `npm run format:check` — clean
- [x] Dev server: three cards render above toolbar on `/`
- [x] Click a card → flips smoothly, back shows description + notes
- [x] Keyboard: Tab to card → Space/Enter flips, focus ring visible
- [x] Click "Hide" → grid collapses; reload → stays collapsed
- [x] Switch to map view → Today's picks hidden
- [x] 375px mobile: cards stack to one column, no horizontal scroll
- [x] Reduced-motion OS setting respected via `motion-reduce:transition-none`
- [x] Screen reader: only the visible face is in the a11y tree (verified via snapshot)