### PR TITLE
:sparkles: Smart search — natural-language filter (AskBar)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import MapView from './components/MapView.vue'
 import VisitProgress from './components/VisitProgress.vue'
 import OpenNowChip from './components/OpenNowChip.vue'
 import TodayView from './components/TodayView.vue'
+import AskBar from './components/AskBar.vue'
 import { parseOpeningHours, isOpen } from './utils/hoursBasic'
 import spacesData from './data/spaces.json'
 
@@ -106,6 +107,10 @@ const filteredSpaces = computed(() => {
 function toggleOpenNow() {
   filters.value = { ...filters.value, openNow: !filters.value.openNow }
 }
+
+function applyAskPatch(patch: Partial<IFilterState>) {
+  filters.value = { ...filters.value, ...patch }
+}
 </script>
 
 <template>
@@ -133,6 +138,9 @@ function toggleOpenNow() {
     <main class="mx-auto max-w-6xl px-6 py-8">
       <!-- Today's picks (list view only) -->
       <TodayView v-if="viewMode === 'list'" :spaces="spaces" />
+
+      <!-- Smart search: natural-language filter -->
+      <AskBar @apply="applyAskPatch" />
 
       <!-- Toolbar: Space count, Filter toggle, View mode -->
       <div class="mb-4 flex flex-wrap items-center justify-between gap-y-3">

--- a/src/components/AskBar.vue
+++ b/src/components/AskBar.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
+import type { IFilterState } from '../types/space'
+import { parseAsk, type IAskMatch } from '../utils/askParser'
+
+const emit = defineEmits<{
+  (e: 'apply', patch: Partial<IFilterState>): void
+}>()
+
+const rawInput = ref('')
+const thinking = ref(false)
+const matches = ref<IAskMatch[]>([])
+
+const EXAMPLES = [
+  'Somewhere quiet with strong wifi…',
+  "I need AC, it's boiling today…",
+  'Open now, a bit hungry…',
+  'Buzzy vibe with snacks and plugs…',
+  'Fast wifi for a zoom call…',
+  'Deep-work spot with plenty of outlets…',
+]
+const placeholderIdx = ref(0)
+const placeholderText = computed(() => EXAMPLES[placeholderIdx.value])
+let placeholderTimer: number | undefined
+
+onMounted(() => {
+  placeholderTimer = window.setInterval(() => {
+    placeholderIdx.value = (placeholderIdx.value + 1) % EXAMPLES.length
+  }, 4000)
+})
+
+let debounceTimer: number | undefined
+let lastAppliedKeys = new Set<keyof IFilterState>()
+
+function defaultFor(key: keyof IFilterState): IFilterState[keyof IFilterState] {
+  if (key === 'openNow') return false
+  return 'all'
+}
+
+function runParse(val: string) {
+  const parsed = parseAsk(val)
+  const newKeys = new Set(Object.keys(parsed.filterPatch) as (keyof IFilterState)[])
+  const patch: Partial<IFilterState> = { ...parsed.filterPatch }
+  for (const key of lastAppliedKeys) {
+    if (!newKeys.has(key)) {
+      ;(patch as Record<string, unknown>)[key] = defaultFor(key)
+    }
+  }
+  lastAppliedKeys = newKeys
+  matches.value = parsed.matches
+  emit('apply', patch)
+}
+
+watch(rawInput, (val) => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  if (!val.trim()) {
+    thinking.value = false
+    if (lastAppliedKeys.size > 0) {
+      runParse('')
+    } else {
+      matches.value = []
+    }
+    return
+  }
+  thinking.value = true
+  const delay = 550 + Math.floor(Math.random() * 300)
+  debounceTimer = window.setTimeout(() => {
+    runParse(val)
+    thinking.value = false
+  }, delay)
+})
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function removeChip(match: IAskMatch) {
+  const re = new RegExp(`\\b${escapeRegex(match.phrase)}\\b`, 'ig')
+  rawInput.value = rawInput.value
+    .replace(re, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+function clearAll() {
+  rawInput.value = ''
+}
+
+onBeforeUnmount(() => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  if (placeholderTimer) clearInterval(placeholderTimer)
+})
+</script>
+
+<template>
+  <div class="mb-5">
+    <div class="relative">
+      <span
+        class="pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-base text-[#ed8936]"
+        aria-hidden="true"
+      >
+        ✨
+      </span>
+      <input
+        v-model="rawInput"
+        type="text"
+        :placeholder="placeholderText"
+        class="w-full rounded-lg border-2 border-[#e2d9c8] bg-white py-3 pr-24 pl-11 text-sm text-[#1a365d] placeholder:text-[#a0aec0] focus:border-[#ed8936] focus:outline-none"
+        aria-label="Describe what you need — smart search"
+      />
+      <div
+        v-if="thinking"
+        class="pointer-events-none absolute top-1/2 right-4 flex -translate-y-1/2 items-center gap-1.5 text-xs text-[#718096]"
+        aria-live="polite"
+      >
+        <span>Thinking</span>
+        <span class="flex gap-0.5">
+          <span
+            class="inline-block h-1 w-1 animate-bounce rounded-full bg-[#ed8936] [animation-delay:0ms] motion-reduce:animate-none"
+          ></span>
+          <span
+            class="inline-block h-1 w-1 animate-bounce rounded-full bg-[#ed8936] [animation-delay:150ms] motion-reduce:animate-none"
+          ></span>
+          <span
+            class="inline-block h-1 w-1 animate-bounce rounded-full bg-[#ed8936] [animation-delay:300ms] motion-reduce:animate-none"
+          ></span>
+        </span>
+      </div>
+      <button
+        v-else-if="rawInput"
+        type="button"
+        class="absolute top-1/2 right-2 -translate-y-1/2 rounded px-2 py-1 text-xs font-medium text-[#718096] transition-colors hover:text-[#1a365d] focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:outline-none"
+        @click="clearAll"
+      >
+        Clear
+      </button>
+    </div>
+
+    <div
+      v-if="matches.length > 0"
+      class="mt-2 flex flex-wrap items-center gap-2"
+      aria-label="Matched filters — click to remove"
+    >
+      <span class="text-xs text-[#718096]">Matched:</span>
+      <button
+        v-for="m in matches"
+        :key="m.filter"
+        type="button"
+        class="group inline-flex items-center gap-1.5 rounded-full bg-[#ed8936] px-3 py-1 text-xs font-semibold text-white transition-colors hover:bg-[#dd7826] focus-visible:ring-2 focus-visible:ring-[#1a365d] focus-visible:outline-none"
+        :aria-label="`Remove ${m.label} filter`"
+        @click="removeChip(m)"
+      >
+        <span>{{ m.label }}</span>
+        <span aria-hidden="true" class="opacity-70 transition-opacity group-hover:opacity-100">
+          ×
+        </span>
+      </button>
+    </div>
+
+    <p v-else-if="rawInput && !thinking" class="mt-2 text-xs text-[#a0aec0]" aria-live="polite">
+      Try "quiet", "fast wifi", or "AC"
+    </p>
+  </div>
+</template>

--- a/src/utils/askParser.ts
+++ b/src/utils/askParser.ts
@@ -1,0 +1,299 @@
+import type { IFilterState } from '../types/space'
+
+export interface IAskMatch {
+  phrase: string
+  filter: keyof IFilterState
+  value: IFilterState[keyof IFilterState]
+  label: string
+}
+
+export interface IAskResult {
+  matches: IAskMatch[]
+  filterPatch: Partial<IFilterState>
+}
+
+interface IPhraseEntry {
+  phrase: string
+  filter: keyof IFilterState
+  value: IFilterState[keyof IFilterState]
+  label: string
+}
+
+const entries = (
+  phrases: string[],
+  filter: keyof IFilterState,
+  value: IFilterState[keyof IFilterState],
+  label: string,
+): IPhraseEntry[] => phrases.map((phrase) => ({ phrase, filter, value, label }))
+
+const PHRASES: IPhraseEntry[] = [
+  ...entries(
+    [
+      'quiet',
+      'silent',
+      'silence',
+      'calm',
+      'peaceful',
+      'focus',
+      'focused',
+      'deep work',
+      'deep-work',
+      'concentrate',
+      'concentration',
+      'study',
+      'studying',
+      'reading',
+      'no noise',
+      'library',
+      'library-like',
+      'zen',
+      'meditative',
+      'no distractions',
+      'no distraction',
+      'heads down',
+      'heads-down',
+    ],
+    'noiseLevel',
+    'quiet',
+    'Quiet',
+  ),
+  ...entries(
+    [
+      'lively',
+      'buzzy',
+      'buzz',
+      'social',
+      'chatty',
+      'vibrant',
+      'energetic',
+      'bustling',
+      'noisy',
+      'loud',
+    ],
+    'noiseLevel',
+    'loud',
+    'Lively',
+  ),
+  ...entries(
+    [
+      'fast wifi',
+      'fast internet',
+      'strong wifi',
+      'strong internet',
+      'good wifi',
+      'great wifi',
+      'reliable wifi',
+      'fast connection',
+      'zoom',
+      'zoom call',
+      'zoom calls',
+      'video call',
+      'video calls',
+      'video meeting',
+      'video meetings',
+      'meetings',
+      'meeting',
+      'streaming',
+      'stream',
+      'heavy upload',
+      'big upload',
+      'big download',
+      'bandwidth',
+      'high bandwidth',
+    ],
+    'wifiSpeed',
+    'fast',
+    'Fast WiFi',
+  ),
+  ...entries(
+    [
+      'hot',
+      'warm',
+      'heatwave',
+      'heat wave',
+      'ac',
+      'a/c',
+      'air conditioning',
+      'air-conditioning',
+      'air con',
+      'aircon',
+      'air-con',
+      'cooling',
+      'cool down',
+      'summer',
+      'hot day',
+      "it's hot",
+      'boiling',
+      'sweating',
+      'sweaty',
+    ],
+    'hasAC',
+    'yes',
+    'Air Conditioning',
+  ),
+  ...entries(
+    [
+      'outlet',
+      'outlets',
+      'plug',
+      'plugs',
+      'plug socket',
+      'plug sockets',
+      'charge',
+      'charger',
+      'charging',
+      'power',
+      'sockets',
+      'socket',
+      'battery dying',
+      'laptop dying',
+      'need power',
+      'power outlet',
+      'every table',
+    ],
+    'hasOutlets',
+    'many',
+    'Plenty of Outlets',
+  ),
+  ...entries(
+    [
+      'lunch',
+      'dinner',
+      'hungry',
+      'meal',
+      'meals',
+      'brunch',
+      'food',
+      'hot food',
+      'hot meal',
+      'hot meals',
+      'full menu',
+      'proper meal',
+      'proper food',
+    ],
+    'foodAvailability',
+    'full',
+    'Full Menu',
+  ),
+  ...entries(
+    [
+      'snack',
+      'snacks',
+      'pastry',
+      'pastries',
+      'cake',
+      'cakes',
+      'cookie',
+      'cookies',
+      'croissant',
+      'croissants',
+      'light bite',
+      'light bites',
+      'something small',
+      'sandwich',
+      'sandwiches',
+    ],
+    'foodAvailability',
+    'light',
+    'Snacks',
+  ),
+  ...entries(
+    [
+      'open now',
+      'open right now',
+      'right now',
+      'currently open',
+      'available now',
+      'now open',
+      'is it open',
+      'open today',
+      'open at the moment',
+    ],
+    'openNow',
+    true,
+    'Open Now',
+  ),
+  ...entries(
+    ['verified', 'confirmed', 'trusted', 'visited', 'personally visited'],
+    'verified',
+    'verified',
+    'Verified',
+  ),
+]
+
+const SORTED_PHRASES = [...PHRASES].sort((a, b) => b.phrase.length - a.phrase.length)
+
+interface IRawMatch {
+  entry: IPhraseEntry
+  start: number
+  end: number
+}
+
+function isWordBoundary(ch: string | undefined): boolean {
+  return !ch || !/[a-z0-9]/.test(ch)
+}
+
+export function parseAsk(query: string): IAskResult {
+  const normalized = query.toLowerCase()
+  const rawMatches: IRawMatch[] = []
+
+  for (const entry of SORTED_PHRASES) {
+    const needle = entry.phrase.toLowerCase()
+    let from = 0
+    while (from <= normalized.length - needle.length) {
+      const idx = normalized.indexOf(needle, from)
+      if (idx === -1) break
+      const before = idx > 0 ? normalized[idx - 1] : undefined
+      const after =
+        idx + needle.length < normalized.length ? normalized[idx + needle.length] : undefined
+      if (!isWordBoundary(before) || !isWordBoundary(after)) {
+        from = idx + 1
+        continue
+      }
+      rawMatches.push({ entry, start: idx, end: idx + needle.length })
+      from = idx + needle.length
+    }
+  }
+
+  // Remove overlapping shorter matches (longest phrase wins)
+  rawMatches.sort((a, b) => b.end - b.start - (a.end - a.start))
+  const consumed = new Array<boolean>(normalized.length).fill(false)
+  const kept: IRawMatch[] = []
+  for (const m of rawMatches) {
+    let overlap = false
+    for (let i = m.start; i < m.end; i++) {
+      if (consumed[i]) {
+        overlap = true
+        break
+      }
+    }
+    if (overlap) continue
+    for (let i = m.start; i < m.end; i++) consumed[i] = true
+    kept.push(m)
+  }
+
+  // Per filter, later position wins (natural reading flow)
+  const byFilter = new Map<keyof IFilterState, IRawMatch>()
+  for (const m of kept) {
+    const existing = byFilter.get(m.entry.filter)
+    if (!existing || m.start > existing.start) {
+      byFilter.set(m.entry.filter, m)
+    }
+  }
+
+  // Emit chips in query order
+  const winners = [...byFilter.values()].sort((a, b) => a.start - b.start)
+  const matches: IAskMatch[] = []
+  const filterPatch: Partial<IFilterState> = {}
+  for (const m of winners) {
+    matches.push({
+      phrase: m.entry.phrase,
+      filter: m.entry.filter,
+      value: m.entry.value,
+      label: m.entry.label,
+    })
+    ;(filterPatch as Record<string, unknown>)[m.entry.filter] = m.entry.value
+  }
+
+  return { matches, filterPatch }
+}

--- a/tests/askParser.test.ts
+++ b/tests/askParser.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { parseAsk } from '../src/utils/askParser'
+
+describe('parseAsk', () => {
+  it('returns empty matches for empty input', () => {
+    const r = parseAsk('')
+    expect(r.matches).toEqual([])
+    expect(r.filterPatch).toEqual({})
+  })
+
+  it('returns empty matches for whitespace', () => {
+    const r = parseAsk('   ')
+    expect(r.matches).toEqual([])
+    expect(r.filterPatch).toEqual({})
+  })
+
+  it('returns empty matches for garbage with no known phrases', () => {
+    const r = parseAsk('xyzzy plover frobnicate')
+    expect(r.matches).toEqual([])
+    expect(r.filterPatch).toEqual({})
+  })
+
+  it('matches "quiet" → noiseLevel=quiet', () => {
+    const r = parseAsk('somewhere quiet please')
+    expect(r.filterPatch).toEqual({ noiseLevel: 'quiet' })
+    expect(r.matches.map((m) => m.label)).toEqual(['Quiet'])
+  })
+
+  it('matches "deep work" (multi-word) → noiseLevel=quiet', () => {
+    const r = parseAsk('need a deep work spot')
+    expect(r.filterPatch).toEqual({ noiseLevel: 'quiet' })
+  })
+
+  it('matches "lively" → noiseLevel=loud', () => {
+    const r = parseAsk('looking for somewhere lively and buzzy')
+    expect(r.filterPatch).toEqual({ noiseLevel: 'loud' })
+  })
+
+  it('matches "fast wifi" → wifiSpeed=fast', () => {
+    const r = parseAsk('i need fast wifi for uploads')
+    expect(r.filterPatch).toEqual({ wifiSpeed: 'fast' })
+  })
+
+  it('matches "zoom" → wifiSpeed=fast', () => {
+    const r = parseAsk('have a zoom in 20 min')
+    expect(r.filterPatch).toEqual({ wifiSpeed: 'fast' })
+  })
+
+  it('matches "hot" → hasAC=yes', () => {
+    const r = parseAsk('so hot today')
+    expect(r.filterPatch).toEqual({ hasAC: 'yes' })
+  })
+
+  it('matches "air con" (2-word phrase) → hasAC=yes', () => {
+    const r = parseAsk('need somewhere with air con')
+    expect(r.filterPatch).toEqual({ hasAC: 'yes' })
+  })
+
+  it('matches "outlets" → hasOutlets=many', () => {
+    const r = parseAsk('many outlets please')
+    expect(r.filterPatch).toEqual({ hasOutlets: 'many' })
+  })
+
+  it('matches "battery dying" → hasOutlets=many', () => {
+    const r = parseAsk('my battery is dying — battery dying here')
+    expect(r.filterPatch).toEqual({ hasOutlets: 'many' })
+  })
+
+  it('matches "lunch" → foodAvailability=full', () => {
+    const r = parseAsk('need lunch')
+    expect(r.filterPatch).toEqual({ foodAvailability: 'full' })
+  })
+
+  it('matches "pastry" → foodAvailability=light', () => {
+    const r = parseAsk('just a pastry to go with my coffee')
+    expect(r.filterPatch).toEqual({ foodAvailability: 'light' })
+  })
+
+  it('matches "hot food" (multi-word beats "hot" AC match)', () => {
+    const r = parseAsk('need hot food')
+    expect(r.filterPatch).toEqual({ foodAvailability: 'full' })
+    // "hot" alone should NOT also trigger hasAC because it was consumed by "hot food"
+    expect(r.filterPatch.hasAC).toBeUndefined()
+  })
+
+  it('matches "open now" → openNow=true', () => {
+    const r = parseAsk('what is open now')
+    expect(r.filterPatch).toEqual({ openNow: true })
+  })
+
+  it('matches "verified" → verified=verified', () => {
+    const r = parseAsk('only verified places')
+    expect(r.filterPatch).toEqual({ verified: 'verified' })
+  })
+
+  it('combines multiple filters from one query', () => {
+    const r = parseAsk('quiet spot with fast wifi and ac, open now')
+    expect(r.filterPatch).toEqual({
+      noiseLevel: 'quiet',
+      wifiSpeed: 'fast',
+      hasAC: 'yes',
+      openNow: true,
+    })
+    expect(r.matches).toHaveLength(4)
+  })
+
+  it('later match wins for same filter (reading-flow override)', () => {
+    const r = parseAsk('somewhere quiet but actually lively')
+    expect(r.filterPatch).toEqual({ noiseLevel: 'loud' })
+  })
+
+  it('emits chips in query order, not dictionary order', () => {
+    const r = parseAsk('hot today and need a zoom call')
+    expect(r.matches.map((m) => m.label)).toEqual(['Air Conditioning', 'Fast WiFi'])
+  })
+
+  it('word boundary: "focus" matches, "focusable" does not', () => {
+    const r = parseAsk('focusable elements')
+    expect(r.filterPatch).toEqual({})
+  })
+
+  it('word boundary: "ac" matches as standalone word', () => {
+    const r = parseAsk('ac please')
+    expect(r.filterPatch).toEqual({ hasAC: 'yes' })
+  })
+
+  it('word boundary: "ac" inside "acoustic" does not match', () => {
+    const r = parseAsk('acoustic tiles')
+    expect(r.filterPatch).toEqual({})
+  })
+
+  it('case insensitive', () => {
+    const r = parseAsk('QUIET please')
+    expect(r.filterPatch).toEqual({ noiseLevel: 'quiet' })
+  })
+
+  it('longest match wins for overlapping phrases', () => {
+    // "air conditioning" should beat "ac" if both were to match same span
+    const r = parseAsk('air conditioning required')
+    expect(r.filterPatch).toEqual({ hasAC: 'yes' })
+    expect(r.matches).toHaveLength(1)
+    expect(r.matches[0].phrase).toBe('air conditioning')
+  })
+
+  it('punctuation does not break matching', () => {
+    const r = parseAsk('quiet, with fast wifi!')
+    expect(r.filterPatch).toEqual({ noiseLevel: 'quiet', wifiSpeed: 'fast' })
+  })
+
+  it('chips include phrase for debuggability', () => {
+    const r = parseAsk('need fast wifi')
+    expect(r.matches[0].phrase).toBe('fast wifi')
+    expect(r.matches[0].filter).toBe('wifiSpeed')
+    expect(r.matches[0].value).toBe('fast')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a natural-language filter bar above the toolbar. User types phrases like `"somewhere quiet with fast wifi"` or `"it's hot and I'm hungry"` and the matching filters apply automatically — chips appear showing what was matched, URL params sync, existing filter UI stays in sync.

Feels LLM-ish without being one: a phrase dictionary (~140 phrases across 9 groups) + two-pass matcher (longest-wins overlap resolution, per-filter later-position-wins, chips in query order) + a 550–850ms "Thinking..." delay so it doesn't feel too fast.

## What's in the diff (627 lines, 4 files)

- `src/utils/askParser.ts` (299) — pure parser, 27-phrase groups mapped to filter state
- `src/components/AskBar.vue` (164) — debounced input, cycling placeholder, Thinking dots, removable chips, Clear button
- `tests/askParser.test.ts` (156) — 27 tests covering word boundaries, overlaps, longest-wins, case insensitivity, multi-filter queries
- `src/App.vue` (+8) — wires AskBar above the toolbar via `applyAskPatch` handler

## Gates

- [x] `npm test` — 58/58 (3 files)
- [x] `vue-tsc --noEmit` — clean
- [x] `npm run build` — clean (209 kB → 70 kB gzip)
- [x] `npm run format:check` — clean
- [x] `/qa` — 0 issues, 8 flows verified (desktop + mobile 375px + keyboard tab order). Report: `.gstack/qa-reports/qa-report-localhost-2026-04-22-smart-search.md`
- [x] Adversarial review — no ship-blockers

## Test plan

- [ ] Type `"somewhere quiet with fast wifi"` — chips show Quiet + Fast WiFi, list narrows
- [ ] Type `"it's really hot today"` — Air Conditioning chip, hasAC filter applies
- [ ] Type `"quiet spot, zoom call, outlets, hungry"` — 4 chips in query order
- [ ] Click chip × — phrase disappears from input, filter resets
- [ ] Click Clear — input empties, all ask-applied filters reset
- [ ] Replace input text — old filters reset, new ones apply
- [ ] Mobile 375px — input wraps, chips wrap, tab order intact