### PR TITLE
:lipstick: Close design-debt: theme tokens, a11y, parser guard

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,7 @@ Brand mood: _neighbourhood cafe directory_, not tech product. Warm paper-cream b
 - **Adding a new colour?** Check **Palette** first. If it's not there, either it maps to an existing hue (use that) or it's a new token — add a row here before you ship.
 - **Building a new component?** Read **Component conventions** — button shape, focus ring, touch-target minimum, and emoji-prefix rule are all prescriptive.
 - **Auditing contrast or keyboard nav?** See **Accessibility baseline**.
-- **Wondering why palette values aren't `bg-primary`?** That's in **Design debt** — it's known, not accidental.
+- **Reaching for a hex code in a class?** Don't. The palette lives as `@theme` tokens in `src/style.css`. Use `bg-primary`, `text-accent`, `border-warm`, etc. New hexes need a token row above before they ship.
 
 Rules in this doc are **prescriptive** unless marked otherwise. Anything under "Design debt" is a known gap with a plan.
 
@@ -217,7 +217,7 @@ No `transform` transitions, no `scale`/`translate` on hover, no new easing curve
 
 **Touch targets.** 44×44 CSS px minimum (Apple HIG). See `min-h-[44px]` rule in Component conventions.
 
-**Reduced motion.** Not currently implemented. The `duration-200` card hover and `duration-500` progress fill will play for everyone regardless of `prefers-reduced-motion`. Low-priority debt — transitions are subtle — but should be fixed before adding any transform-based animations. See **Design debt**.
+**Reduced motion.** Honored. Every `transition-*` utility in components is paired with `motion-reduce:transition-none`, and the bouncing thinking dots in `AskBar` use `motion-reduce:animate-none`. Add the same pairing to any new transition or animation you introduce.
 
 ---
 
@@ -235,12 +235,7 @@ Design forks the project hasn't resolved. Not debt (debt has a plan) — these a
 
 ## Design debt
 
-- **CSS custom properties in `style.css` are unused.** Components inline the same hex values in Tailwind bracket classes. Consequence: renaming a brand colour today requires editing ~7 component files instead of one variable.
-  - Options:
-    1. Migrate components to `bg-[var(--color-primary)]` — works but keeps the dual source of truth.
-    2. Move to Tailwind 4 `@theme` block in `style.css` — registers real design tokens so classes like `bg-primary` / `text-accent` work natively. Recommended.
-  - Scope: ~30 min, touches every component but only via find-and-replace.
-- **Hues outside the seven named vars** (navy-hover, navy-track, cream-deep, warm-border, cool-border, cream-surface, orange-hover, ink, body-muted, placeholder) need names before we can promote to tokens — hence this doc.
-- **No `prefers-reduced-motion` handling.** All transitions play regardless of OS setting. Low-priority for current motion set (subtle fades) but will become a real issue if we ever add transform/scale. Fix: add a `motion-reduce:transition-none` variant to the motion tokens in Component conventions. ~10 min.
-- **Focus-ring rule not universally applied.** The prescribed `focus-visible:ring-2 focus-visible:ring-[#ed8936]` pattern lives only on `OpenNowChip.vue`. `FilterBar.vue` selects use `focus:border-[#ed8936] focus:outline-none` (no ring — relies on border colour change only); sort buttons have no focus treatment at all. Consequence: keyboard users on the filter panel get a weaker focus cue than on the chip. Fix: audit all interactive elements, apply the prescribed ring pattern. ~15 min.
+- ~~**CSS custom properties in `style.css` are unused.**~~ Resolved. `style.css` now declares Tailwind 4 `@theme` tokens (`primary`, `primary-hover`, `primary-track`, `accent`, `accent-hover`, `cream`, `cream-panel`, `cream-deep`, `warm`, `cool`, `ink`, `body`, `muted`, `faint`). Components use `bg-primary`, `text-accent`, `border-warm`, etc. No more `[#hex]` bracket classes anywhere in `src/`.
+- ~~**No `prefers-reduced-motion` handling.**~~ Resolved. Every `transition-(colors|all|transform|opacity)` utility is paired with `motion-reduce:transition-none`. The bouncing dots in `AskBar` use `motion-reduce:animate-none`.
+- ~~**Focus-ring rule not universally applied.**~~ Resolved. The prescribed `focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:outline-none` pattern is applied to every interactive element. Two known exceptions, both deliberate: (a) controls inside the segmented View toggle use `focus-visible:ring-inset` because the parent is `overflow-hidden`; (b) chip-internal controls in `AskBar` (the × on each match chip and the absolute-positioned Clear button) omit `ring-offset-2` because the offset would extend beyond the chip pill.
 - **No dark mode.** Cream-first palette doesn't currently map to a dark counterpart. Defer until there's a user ask.

--- a/TODOS.md
+++ b/TODOS.md
@@ -12,6 +12,23 @@
 - [x] App.vue: chip mounted in toolbar next to Filters/View toggle, URL syncs `?openNow=1`, wraps on mobile
 - [x] Empty state: context-aware copy when `openNow` active with 0 matches (generic "nothing open" vs "nothing open + other filters")
 
+## Weekend 2: Today's Picks (flip cards) ✅ Shipped
+
+- [x] `src/utils/featuredSpaces.ts` — date-seeded picker, three spaces per day, deterministic across reloads, prefers verified spaces
+- [x] `tests/featuredSpaces.test.ts` — 13 tests: determinism, verified bias, fallback when too few verified, edge cases
+- [x] `src/components/FeaturedCard.vue` — CSS flip card, `[backface-visibility:hidden]` so screen readers don't double-read, `motion-reduce:transition-none` honored
+- [x] `src/components/TodayView.vue` — three-card grid, refresh button to re-roll seed, hidden in map view
+- [x] App.vue: TodayView mounted above the toolbar in list view only
+
+## Weekend 3: Smart search AskBar ✅ Shipped
+
+- [x] `src/utils/askParser.ts` — phrase dictionary (~140 phrases), longest-wins overlap, per-filter later-position-wins, chips in query order
+- [x] `tests/askParser.test.ts` — 28 tests covering matching, overlap, punctuation, case, length guard
+- [x] `src/components/AskBar.vue` — debounced "Thinking…" UI (550–850ms), removable chips, rotating placeholder examples
+- [x] App.vue: AskBar mounted above the toolbar, emits `apply` patches into the filter ref
+- [x] `lastAppliedKeys` mechanism resets filters when matching phrases leave the input
+- [x] Pathological-input guard: `parseAsk` truncates queries to 1000 chars before scanning
+
 ## Descoped from original plan
 
 - [ ] ~~`weatherFit: boolean` filter + weather-appropriate sort~~ — shipped as **emoji-only aliveness signal in chip label**. Revisit if users ask for it. If you bring it back: add a second boolean to IFilterState, rank spaces by `indoor vs outdoor` metadata (which doesn't exist in spaces.json yet — would require schema extension).
@@ -27,21 +44,25 @@
 - [ ] Weather failure: throttle network to offline in devtools, hard refresh — chip falls back to plain "Open now" label (no weather)
 - [ ] Weather cache: toggle chip multiple times in a session — Network tab shows only one `api.open-meteo.com` request
 
-## Design debt (not blocking ship)
+## Design debt
 
 - [x] Extract implicit palette into `DESIGN.md` — shipped. Doc captures 22 named hues, typography, component conventions, a11y baseline.
 - [x] 7-pass design-system review of `DESIGN.md` — shipped. Added TOC + "How to use", Layout & responsive section (breakpoints, container, grids, spacing), iconography policy, deviation rubric, full state/variant tables, three-token motion system, explicit contrast pairs, screen-reader patterns, Open questions section. Final rating: 8.5/10 avg across 7 passes.
-- [ ] Migrate components from `bg-[#hex]` to Tailwind 4 `@theme` tokens (`bg-primary`, `text-accent`, etc.) — see DESIGN.md "Design debt" section. ~30 min, touches ~7 files via find-and-replace.
-- [ ] **Apply focus-ring rule uniformly.** `FilterBar.vue` selects + sort buttons lack the prescribed `focus-visible:ring-2 focus-visible:ring-[#ed8936]` pattern. ~15 min. See DESIGN.md Design debt.
-- [ ] **Add `motion-reduce:transition-none` to motion tokens.** No current `prefers-reduced-motion` handling. ~10 min. Low priority while transitions stay subtle.
+- [x] Migrate components from `bg-[#hex]` to Tailwind 4 `@theme` tokens — shipped. `src/style.css` defines 14 named tokens (`primary`, `accent`, `cream`, `cream-panel`, `cream-deep`, `warm`, `cool`, `ink`, `body`, `muted`, `faint`, plus brand hovers and `primary-track`). All 11 components migrated.
+- [x] **Apply focus-ring rule uniformly.** Shipped. `FilterBar` selects + sort buttons + Clear-all, App-level Filter/View toggles + footer CTAs + footer text links, `SpaceCard` collapsible toggle, `SpaceSummary` visit-tick + Help-verify links + address link, `VisitProgress` undo button, and the AskBar input all carry `focus-visible:ring-2 focus-visible:ring-accent` (offset-2 except where parent is `overflow-hidden`, which uses `ring-inset`).
+- [x] **Add `motion-reduce:transition-none` to motion tokens.** Shipped. Every `transition-(colors|all|transform|opacity)` instance is paired with `motion-reduce:transition-none` so `prefers-reduced-motion` cuts animations to zero.
 
 ## Explicitly not doing (yet)
 
-- ~~Three flip cards / TodayView~~
-- ~~LLM blurbs (Groq / templates)~~
-- ~~Ask-a-Friend chat~~
-- ~~Fuse.js, SunCalc, novelty cache~~
-- ~~`/` vs `/all` routing split~~
+- ~~Three flip cards / TodayView~~ — shipped Weekend 2
+- ~~LLM blurbs (Groq / templates)~~ — would require a backend, deferred indefinitely
+- ~~Ask-a-Friend chat~~ — backend dependency, deferred
+- ~~Fuse.js (fuzzy space-name search)~~ — AskBar covers the need; revisit if exact-name search misses
+- ~~SunCalc, novelty cache~~ — deferred
+- ~~`/` vs `/all` routing split~~ — current single-page layout is fine
 - ~~Two separate chips (open + weather)~~ — one compound chip instead
 
-Revisit flip cards only after shipping the chip and seeing whether it feels alive.
+## Future ideas (not committed)
+
+- **Novelty cache for Today's Picks** — track recently-shown spaces in `localStorage` so the daily roll doesn't repeat last week's picks. Worth building if users mention seeing the same cards every day.
+- **AskBar/FilterBar conflict resolver** — currently if a user manually toggles a filter while a matching phrase still sits in the Ask input, the next debounced re-parse silently re-applies the Ask value. Add `AskBar` watching the parent `filters` ref and skip re-emitting filters whose value was externally changed. Only worth it if a user reports confusion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
         "vite": "^7.3.2",
+        "vitest": "^4.1.5",
         "vue-tsc": "^3.1.4"
       }
     },
@@ -908,6 +909,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "dev": true,
@@ -1232,6 +1240,24 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
@@ -1246,6 +1272,7 @@
       "version": "1.9.21",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -1254,6 +1281,7 @@
       "version": "24.10.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1277,6 +1305,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1474,6 +1625,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "license": "MIT"
@@ -1507,6 +1685,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -1552,6 +1737,16 @@
       "version": "2.0.2",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "dev": true,
@@ -1595,7 +1790,8 @@
     },
     "node_modules/leaflet": {
       "version": "1.9.4",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/lightningcss": {
       "version": "1.30.2",
@@ -1882,8 +2078,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1897,6 +2111,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1936,6 +2151,7 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -2070,12 +2286,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
@@ -2094,6 +2331,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "dev": true,
@@ -2109,6 +2363,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tippy.js": {
       "version": "6.3.7",
       "license": "MIT",
@@ -2120,6 +2384,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2139,6 +2404,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2208,6 +2474,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "dev": true,
@@ -2216,6 +2572,7 @@
     "node_modules/vue": {
       "version": "3.5.26",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -2255,6 +2612,23 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,9 +114,9 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 </script>
 
 <template>
-  <div class="min-h-screen bg-[#fffaf0]">
+  <div class="bg-cream min-h-screen">
     <!-- Header -->
-    <header class="bg-[#1a365d] px-4 py-6 text-white sm:px-6 sm:py-8">
+    <header class="bg-primary px-4 py-6 text-white sm:px-6 sm:py-8">
       <div class="mx-auto flex max-w-6xl items-center gap-4 sm:gap-6">
         <img
           src="/favicon.svg"
@@ -127,9 +127,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
           <h1 class="font-display m-0 mb-1 text-2xl font-bold sm:mb-2 sm:text-4xl md:text-5xl">
             Leuven Coworking Cafes
           </h1>
-          <p class="m-0 text-sm text-[#cbd5e0] sm:text-lg">
-            Find your perfect spot to work in Leuven
-          </p>
+          <p class="text-cool m-0 text-sm sm:text-lg">Find your perfect spot to work in Leuven</p>
         </div>
       </div>
     </header>
@@ -144,7 +142,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 
       <!-- Toolbar: Space count, Filter toggle, View mode -->
       <div class="mb-4 flex flex-wrap items-center justify-between gap-y-3">
-        <p class="m-0 text-sm text-[#718096]">
+        <p class="text-muted m-0 text-sm">
           Showing {{ filteredSpaces.length }} of {{ spaces.length }} spaces
         </p>
 
@@ -154,11 +152,11 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 
           <!-- Filter Toggle -->
           <button
-            class="flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors"
+            class="focus-visible:ring-accent flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
             :class="
               showFilters
-                ? 'border-[#1a365d] bg-[#1a365d] text-white'
-                : 'border-[#1a365d] bg-white text-[#1a365d] hover:bg-[#f5f0e6]'
+                ? 'border-primary bg-primary text-white'
+                : 'border-primary text-primary hover:bg-cream-panel bg-white'
             "
             @click="showFilters = !showFilters"
           >
@@ -166,31 +164,31 @@ function applyAskPatch(patch: Partial<IFilterState>) {
             <span
               v-if="activeFilterCount > 0"
               class="rounded-full px-1.5 py-0.5 text-xs font-bold"
-              :class="showFilters ? 'bg-[#ed8936] text-white' : 'bg-[#ed8936] text-white'"
+              :class="showFilters ? 'bg-accent text-white' : 'bg-accent text-white'"
             >
               {{ activeFilterCount }}
             </span>
           </button>
 
           <!-- View Mode Toggle -->
-          <div class="inline-flex overflow-hidden rounded-lg border-2 border-[#1a365d]">
+          <div class="border-primary inline-flex overflow-hidden rounded-lg border-2">
             <button
-              class="px-4 py-2 text-sm font-medium transition-colors"
+              class="focus-visible:ring-accent px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
               :class="
                 viewMode === 'list'
-                  ? 'bg-[#1a365d] text-white'
-                  : 'bg-white text-[#1a365d] hover:bg-[#f5f0e6]'
+                  ? 'bg-primary text-white'
+                  : 'text-primary hover:bg-cream-panel bg-white'
               "
               @click="viewMode = 'list'"
             >
               📋 List
             </button>
             <button
-              class="border-l-2 border-[#1a365d] px-4 py-2 text-sm font-medium transition-colors"
+              class="border-primary focus-visible:ring-accent border-l-2 px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
               :class="
                 viewMode === 'map'
-                  ? 'bg-[#1a365d] text-white'
-                  : 'bg-white text-[#1a365d] hover:bg-[#f5f0e6]'
+                  ? 'bg-primary text-white'
+                  : 'text-primary hover:bg-cream-panel bg-white'
               "
               @click="viewMode = 'map'"
             >
@@ -217,22 +215,18 @@ function applyAskPatch(patch: Partial<IFilterState>) {
     </main>
 
     <!-- Footer -->
-    <footer class="mt-12 border-t-2 border-[#e2d9c8] bg-[#f5f0e6] px-6 py-8 pb-24">
+    <footer class="border-warm bg-cream-panel mt-12 border-t-2 px-6 py-8 pb-24">
       <div class="mx-auto max-w-6xl space-y-6 text-center">
         <div class="flex flex-col justify-center gap-2 sm:flex-row">
-          <div
-            class="w-full rounded-lg bg-[#1a365d] p-6 text-white sm:w-auto sm:max-w-md sm:flex-1"
-          >
+          <div class="bg-primary w-full rounded-lg p-6 text-white sm:w-auto sm:max-w-md sm:flex-1">
             <p class="m-0 mb-3 text-lg font-medium">🏢 Know a great coworking spot?</p>
-            <p class="m-0 mb-4 text-sm text-[#cbd5e0]">
-              Help fellow remote workers find new places!
-            </p>
+            <p class="text-cool m-0 mb-4 text-sm">Help fellow remote workers find new places!</p>
             <div class="flex flex-wrap justify-center gap-3">
               <a
                 :href="NEW_SPACE_URL"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="rounded bg-[#ed8936] px-4 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-[#dd7826]"
+                class="bg-accent hover:bg-accent-hover focus-visible:ring-accent rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
               >
                 ✨ Suggest via GitHub
               </a>
@@ -240,38 +234,38 @@ function applyAskPatch(patch: Partial<IFilterState>) {
                 href="https://pezcuckow.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="rounded bg-white px-4 py-2 text-sm font-semibold text-[#1a365d] no-underline transition-colors hover:bg-[#f5f0e6]"
+                class="text-primary hover:bg-cream-panel focus-visible:ring-accent rounded bg-white px-4 py-2 text-sm font-semibold no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
               >
                 ✉️ Email me
               </a>
             </div>
           </div>
           <div
-            class="w-full rounded-lg border-2 border-[#ed8936] bg-white p-6 sm:w-auto sm:max-w-md sm:flex-1"
+            class="border-accent w-full rounded-lg border-2 bg-white p-6 sm:w-auto sm:max-w-md sm:flex-1"
           >
-            <p class="m-0 mb-2 text-lg font-medium text-[#1a365d]">
+            <p class="text-primary m-0 mb-2 text-lg font-medium">
               👋 Looking for people to co-work with?
             </p>
-            <p class="m-0 mb-4 text-sm text-[#718096]">
+            <p class="text-muted m-0 mb-4 text-sm">
               <strong>Join</strong> the Leuven Social Groups co-working group!
             </p>
             <a
               href="https://labs.pez.io/leuven-social-groups/"
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-block rounded bg-[#ed8936] px-4 py-2 text-sm font-semibold text-white no-underline transition-colors hover:bg-[#dd7826]"
+              class="bg-accent hover:bg-accent-hover focus-visible:ring-accent inline-block rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
             >
               Learn more →
             </a>
           </div>
         </div>
-        <p class="m-0 text-sm text-[#718096]">
+        <p class="text-muted m-0 text-sm">
           Made with ☕ in Leuven by
           <a
             href="https://pezcuckow.com"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-[#718096] underline hover:text-[#ed8936]"
+            class="text-muted hover:text-accent focus-visible:ring-accent rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Pez
           </a>
@@ -280,7 +274,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
             href="https://github.com/Pezmc/coworking-spaces"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-[#718096] underline hover:text-[#ed8936]"
+            class="text-muted hover:text-accent focus-visible:ring-accent rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Open Source
           </a>

--- a/src/components/AskBar.vue
+++ b/src/components/AskBar.vue
@@ -96,7 +96,7 @@ onBeforeUnmount(() => {
   <div class="mb-5">
     <div class="relative">
       <span
-        class="pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-base text-[#ed8936]"
+        class="text-accent pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-base"
         aria-hidden="true"
       >
         ✨
@@ -105,31 +105,31 @@ onBeforeUnmount(() => {
         v-model="rawInput"
         type="text"
         :placeholder="placeholderText"
-        class="w-full rounded-lg border-2 border-[#e2d9c8] bg-white py-3 pr-24 pl-11 text-sm text-[#1a365d] placeholder:text-[#a0aec0] focus:border-[#ed8936] focus:outline-none"
+        class="border-warm text-primary placeholder:text-faint focus-visible:border-accent focus-visible:ring-accent w-full rounded-lg border-2 bg-white py-3 pr-24 pl-11 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label="Describe what you need — smart search"
       />
       <div
         v-if="thinking"
-        class="pointer-events-none absolute top-1/2 right-4 flex -translate-y-1/2 items-center gap-1.5 text-xs text-[#718096]"
+        class="text-muted pointer-events-none absolute top-1/2 right-4 flex -translate-y-1/2 items-center gap-1.5 text-xs"
         aria-live="polite"
       >
         <span>Thinking</span>
         <span class="flex gap-0.5">
           <span
-            class="inline-block h-1 w-1 animate-bounce rounded-full bg-[#ed8936] [animation-delay:0ms] motion-reduce:animate-none"
+            class="bg-accent inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:0ms] motion-reduce:animate-none"
           ></span>
           <span
-            class="inline-block h-1 w-1 animate-bounce rounded-full bg-[#ed8936] [animation-delay:150ms] motion-reduce:animate-none"
+            class="bg-accent inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:150ms] motion-reduce:animate-none"
           ></span>
           <span
-            class="inline-block h-1 w-1 animate-bounce rounded-full bg-[#ed8936] [animation-delay:300ms] motion-reduce:animate-none"
+            class="bg-accent inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:300ms] motion-reduce:animate-none"
           ></span>
         </span>
       </div>
       <button
         v-else-if="rawInput"
         type="button"
-        class="absolute top-1/2 right-2 -translate-y-1/2 rounded px-2 py-1 text-xs font-medium text-[#718096] transition-colors hover:text-[#1a365d] focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:outline-none"
+        class="text-muted hover:text-primary focus-visible:ring-accent absolute top-1/2 right-2 -translate-y-1/2 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
         @click="clearAll"
       >
         Clear
@@ -141,23 +141,26 @@ onBeforeUnmount(() => {
       class="mt-2 flex flex-wrap items-center gap-2"
       aria-label="Matched filters — click to remove"
     >
-      <span class="text-xs text-[#718096]">Matched:</span>
+      <span class="text-muted text-xs">Matched:</span>
       <button
         v-for="m in matches"
         :key="m.filter"
         type="button"
-        class="group inline-flex items-center gap-1.5 rounded-full bg-[#ed8936] px-3 py-1 text-xs font-semibold text-white transition-colors hover:bg-[#dd7826] focus-visible:ring-2 focus-visible:ring-[#1a365d] focus-visible:outline-none"
+        class="group bg-accent hover:bg-accent-hover focus-visible:ring-primary inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
         :aria-label="`Remove ${m.label} filter`"
         @click="removeChip(m)"
       >
         <span>{{ m.label }}</span>
-        <span aria-hidden="true" class="opacity-70 transition-opacity group-hover:opacity-100">
+        <span
+          aria-hidden="true"
+          class="opacity-70 transition-opacity group-hover:opacity-100 motion-reduce:transition-none"
+        >
           ×
         </span>
       </button>
     </div>
 
-    <p v-else-if="rawInput && !thinking" class="mt-2 text-xs text-[#a0aec0]" aria-live="polite">
+    <p v-else-if="rawInput && !thinking" class="text-faint mt-2 text-xs" aria-live="polite">
       Try "quiet", "fast wifi", or "AC"
     </p>
   </div>

--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -35,7 +35,7 @@ function toggle() {
 <template>
   <button
     type="button"
-    class="group relative block h-64 w-full cursor-pointer rounded-lg text-left [perspective:1000px] focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:outline-none"
+    class="group focus-visible:ring-accent relative block h-64 w-full cursor-pointer rounded-lg text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none"
     :aria-pressed="flipped"
     :aria-label="`${pick.label}: ${pick.space.name} — click to ${flipped ? 'hide' : 'show'} details`"
     @click="toggle"
@@ -46,60 +46,60 @@ function toggle() {
     >
       <!-- Front -->
       <div
-        class="absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 border-[#e2d9c8] bg-white p-5 [backface-visibility:hidden] group-hover:border-[#ed8936]"
+        class="border-warm group-hover:border-accent absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 bg-white p-5 [backface-visibility:hidden]"
         :aria-hidden="flipped"
       >
         <div>
-          <p class="m-0 mb-2 text-xs font-semibold tracking-wide text-[#ed8936] uppercase">
+          <p class="text-accent m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
             {{ pick.label }}
           </p>
-          <h3 class="font-display m-0 mb-1 text-xl font-bold text-[#1a365d]">
+          <h3 class="font-display text-primary m-0 mb-1 text-xl font-bold">
             {{ pick.space.name }}
           </h3>
-          <p class="m-0 text-xs text-[#718096] italic">{{ pick.hook }}</p>
+          <p class="text-muted m-0 text-xs italic">{{ pick.hook }}</p>
         </div>
 
         <div>
-          <p class="m-0 mb-3 line-clamp-3 text-sm text-[#4a5568]">
+          <p class="text-body m-0 mb-3 line-clamp-3 text-sm">
             {{ firstSentence }}
           </p>
           <div class="flex flex-wrap gap-1.5">
             <span
               v-for="pill in pills"
               :key="pill"
-              class="rounded-full bg-[#f5f0e6] px-2 py-0.5 text-xs font-medium text-[#1a365d]"
+              class="bg-cream-panel text-primary rounded-full px-2 py-0.5 text-xs font-medium"
             >
               {{ pill }}
             </span>
           </div>
         </div>
 
-        <span aria-hidden="true" class="absolute right-3 bottom-3 text-xs text-[#a0aec0]">
+        <span aria-hidden="true" class="text-faint absolute right-3 bottom-3 text-xs">
           tap to flip ↻
         </span>
       </div>
 
       <!-- Back -->
       <div
-        class="absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 border-[#ed8936] bg-[#fffaf0] p-5 [backface-visibility:hidden]"
+        class="border-accent bg-cream absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 p-5 [backface-visibility:hidden]"
         :aria-hidden="!flipped"
       >
-        <h3 class="font-display m-0 mb-2 text-lg font-bold text-[#1a365d]">
+        <h3 class="font-display text-primary m-0 mb-2 text-lg font-bold">
           {{ pick.space.name }}
         </h3>
-        <p class="m-0 mb-3 text-sm text-[#4a5568]">{{ pick.space.description }}</p>
+        <p class="text-body m-0 mb-3 text-sm">{{ pick.space.description }}</p>
 
         <div v-if="pick.space.atmosphereNotes" class="mb-2">
-          <p class="m-0 text-xs font-semibold tracking-wide text-[#718096] uppercase">Atmosphere</p>
-          <p class="m-0 text-xs text-[#4a5568]">{{ pick.space.atmosphereNotes }}</p>
+          <p class="text-muted m-0 text-xs font-semibold tracking-wide uppercase">Atmosphere</p>
+          <p class="text-body m-0 text-xs">{{ pick.space.atmosphereNotes }}</p>
         </div>
 
         <div v-if="pick.space.seatingNotes">
-          <p class="m-0 text-xs font-semibold tracking-wide text-[#718096] uppercase">Seating</p>
-          <p class="m-0 text-xs text-[#4a5568]">{{ pick.space.seatingNotes }}</p>
+          <p class="text-muted m-0 text-xs font-semibold tracking-wide uppercase">Seating</p>
+          <p class="text-body m-0 text-xs">{{ pick.space.seatingNotes }}</p>
         </div>
 
-        <span aria-hidden="true" class="absolute right-3 bottom-3 text-xs text-[#a0aec0]">
+        <span aria-hidden="true" class="text-faint absolute right-3 bottom-3 text-xs">
           tap to flip back ↺
         </span>
       </div>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -79,12 +79,12 @@ const sortOptions: { field: SortField; label: string }[] = [
 </script>
 
 <template>
-  <div class="mb-8 rounded-lg border-2 border-[#1a365d] bg-[#f5f0e6] p-5">
+  <div class="border-primary bg-cream-panel mb-8 rounded-lg border-2 p-5">
     <div class="mb-4 flex flex-wrap items-center justify-between gap-4">
-      <h2 class="font-display m-0 text-xl font-bold text-[#1a365d]">Filter Spaces</h2>
+      <h2 class="font-display text-primary m-0 text-xl font-bold">Filter Spaces</h2>
       <button
         v-if="hasActiveFilters"
-        class="cursor-pointer border-0 bg-transparent text-sm text-[#ed8936] underline hover:text-[#dd7826]"
+        class="text-accent hover:text-accent-hover focus-visible:ring-accent cursor-pointer rounded border-0 bg-transparent text-sm underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         @click="resetFilters"
       >
         Clear all filters
@@ -94,10 +94,10 @@ const sortOptions: { field: SortField; label: string }[] = [
     <div class="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-7">
       <!-- Noise Level -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase"> Noise </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Noise </label>
         <select
           :value="filters.noiseLevel"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'noiseLevel',
@@ -114,10 +114,10 @@ const sortOptions: { field: SortField; label: string }[] = [
 
       <!-- WiFi Speed -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase"> WiFi </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> WiFi </label>
         <select
           :value="filters.wifiSpeed"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'wifiSpeed',
@@ -134,12 +134,10 @@ const sortOptions: { field: SortField; label: string }[] = [
 
       <!-- AC -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase">
-          Climate
-        </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Climate </label>
         <select
           :value="filters.hasAC"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'hasAC',
@@ -156,10 +154,10 @@ const sortOptions: { field: SortField; label: string }[] = [
 
       <!-- Food -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase"> Food </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Food </label>
         <select
           :value="filters.foodAvailability"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'foodAvailability',
@@ -176,12 +174,10 @@ const sortOptions: { field: SortField; label: string }[] = [
 
       <!-- Seating -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase">
-          Seating
-        </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Seating </label>
         <select
           :value="filters.seatingType"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'seatingType',
@@ -198,12 +194,10 @@ const sortOptions: { field: SortField; label: string }[] = [
 
       <!-- Outlets -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase">
-          Outlets
-        </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Outlets </label>
         <select
           :value="filters.hasOutlets"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'hasOutlets',
@@ -220,10 +214,10 @@ const sortOptions: { field: SortField; label: string }[] = [
 
       <!-- Verified -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs font-semibold tracking-wide text-[#718096] uppercase"> Status </label>
+        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Status </label>
         <select
           :value="filters.verified"
-          class="cursor-pointer rounded border-2 border-[#cbd5e0] bg-white px-3 py-2 text-sm text-[#1a202c] transition-colors hover:border-[#ed8936] focus:border-[#ed8936] focus:outline-none"
+          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'verified',
@@ -239,17 +233,17 @@ const sortOptions: { field: SortField; label: string }[] = [
     </div>
 
     <!-- Sort -->
-    <div class="flex items-center gap-3 border-t border-[#cbd5e0] pt-4">
-      <span class="text-xs font-semibold tracking-wide text-[#718096] uppercase"> Sort by: </span>
+    <div class="border-cool flex items-center gap-3 border-t pt-4">
+      <span class="text-muted text-xs font-semibold tracking-wide uppercase"> Sort by: </span>
       <div class="flex gap-2">
         <button
           v-for="option in sortOptions"
           :key="option.field"
-          class="cursor-pointer rounded border-2 px-3 py-1.5 text-sm transition-all"
+          class="focus-visible:ring-accent cursor-pointer rounded border-2 px-3 py-1.5 text-sm transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           :class="
             sort.field === option.field
-              ? 'border-[#1a365d] bg-[#1a365d] text-white'
-              : 'border-[#cbd5e0] bg-white text-[#1a365d] hover:border-[#1a365d]'
+              ? 'border-primary bg-primary text-white'
+              : 'border-cool text-primary hover:border-primary bg-white'
           "
           @click="updateSort(option.field)"
         >

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -92,10 +92,7 @@ function getMarkerIcon(space: ICoworkingSpace) {
 </script>
 
 <template>
-  <div
-    class="map-container overflow-hidden rounded-lg border-2 border-[#e2d9c8]"
-    style="height: 600px"
-  >
+  <div class="map-container border-warm overflow-hidden rounded-lg border-2" style="height: 600px">
     <LMap
       ref="mapRef"
       :zoom="zoom"
@@ -127,9 +124,9 @@ function getMarkerIcon(space: ICoworkingSpace) {
     <!-- No results message -->
     <div
       v-if="spaces.filter((s) => s.coordinates).length === 0"
-      class="absolute inset-0 flex items-center justify-center bg-[#f5f0e6]/90"
+      class="bg-cream-panel/90 absolute inset-0 flex items-center justify-center"
     >
-      <p class="text-lg text-[#718096]">No spaces match your filters</p>
+      <p class="text-muted text-lg">No spaces match your filters</p>
     </div>
   </div>
 </template>

--- a/src/components/OpenNowChip.vue
+++ b/src/components/OpenNowChip.vue
@@ -40,11 +40,11 @@ const title = computed(() =>
     :aria-label="ariaLabel"
     :title="title"
     :class="[
-      'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors',
-      'focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:ring-offset-2 focus-visible:outline-none',
+      'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors motion-reduce:transition-none',
+      'focus-visible:ring-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
       active
-        ? 'border-[#1a365d] bg-[#1a365d] text-white hover:bg-[#15284a]'
-        : 'border-[#1a365d] bg-white text-[#1a365d] hover:bg-[#f5f0e6]',
+        ? 'border-primary bg-primary hover:bg-primary-hover text-white'
+        : 'border-primary text-primary hover:bg-cream-panel bg-white',
       loading && 'cursor-wait opacity-70',
     ]"
     @click="emit('toggle')"

--- a/src/components/SpaceCard.vue
+++ b/src/components/SpaceCard.vue
@@ -17,11 +17,11 @@ const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
 
 <template>
   <article
-    class="overflow-hidden rounded-lg border-2 border-[#e2d9c8] bg-white transition-all duration-200 hover:border-[#ed8936] hover:shadow-lg"
+    class="border-warm hover:border-accent overflow-hidden rounded-lg border-2 bg-white transition-all duration-200 hover:shadow-lg motion-reduce:transition-none"
     :class="{ 'opacity-70': !space.verified }"
   >
     <!-- Header with Summary -->
-    <div class="border-b border-[#e2d9c8] p-5">
+    <div class="border-warm border-b p-5">
       <SpaceSummary :space="space">
         <template #title>
           <span :id="slugify(space.name)">{{ space.name }}</span>
@@ -32,93 +32,84 @@ const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
     <!-- Expandable Details -->
     <div class="px-5 py-3">
       <button
-        class="flex w-full cursor-pointer items-center justify-between border-0 bg-transparent py-1 text-sm font-medium text-[#1a365d]"
+        class="text-primary focus-visible:ring-accent flex w-full cursor-pointer items-center justify-between rounded border-0 bg-transparent py-1 text-sm font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         @click="expanded = !expanded"
       >
         <span>{{ expanded ? 'Hide details' : 'Show details' }}</span>
-        <span class="transform transition-transform" :class="{ 'rotate-180': expanded }"> ▼ </span>
+        <span
+          class="transform transition-transform motion-reduce:transition-none"
+          :class="{ 'rotate-180': expanded }"
+        >
+          ▼
+        </span>
       </button>
 
       <div v-show="expanded" class="mt-4 space-y-3 text-sm">
         <!-- Atmosphere -->
         <div v-if="space.atmosphereNotes">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">
             Atmosphere
           </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.atmosphereNotes }}</p>
+          <p class="text-body m-0">{{ space.atmosphereNotes }}</p>
         </div>
 
         <!-- Seating -->
         <div v-if="space.seatingNotes">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            Seating
-          </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.seatingNotes }}</p>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Seating</h4>
+          <p class="text-body m-0">{{ space.seatingNotes }}</p>
         </div>
 
         <!-- WiFi Notes -->
         <div v-if="space.wifiNotes">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            WiFi
-          </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.wifiNotes }}</p>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">WiFi</h4>
+          <p class="text-body m-0">{{ space.wifiNotes }}</p>
         </div>
 
         <!-- Climate -->
         <div v-if="space.climateNotes">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            Climate
-          </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.climateNotes }}</p>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Climate</h4>
+          <p class="text-body m-0">{{ space.climateNotes }}</p>
         </div>
 
         <!-- Outlets -->
         <div>
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            Outlets
-          </h4>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Outlets</h4>
           <p
             v-tippy="OUTLET_DESCRIPTIONS[space.hasOutlets]"
-            class="m-0 inline-block cursor-help text-[#4a5568]"
+            class="text-body m-0 inline-block cursor-help"
           >
             {{ OUTLET_LABELS[space.hasOutlets] }}
           </p>
-          <p v-if="space.outletNotes" class="m-0 mt-1 text-xs text-[#4a5568]">
+          <p v-if="space.outletNotes" class="text-body m-0 mt-1 text-xs">
             {{ space.outletNotes }}
           </p>
         </div>
 
         <!-- Drinks -->
         <div v-if="space.drinkNotes">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            Drinks
-          </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.drinkNotes }}</p>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Drinks</h4>
+          <p class="text-body m-0">{{ space.drinkNotes }}</p>
         </div>
 
         <!-- Food -->
         <div v-if="space.foodNotes">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            Food
-          </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.foodNotes }}</p>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Food</h4>
+          <p class="text-body m-0">{{ space.foodNotes }}</p>
         </div>
 
         <!-- Opening Hours -->
         <div v-if="space.openingHours">
-          <h4 class="m-0 mb-1 text-xs font-semibold tracking-wide text-[#718096] uppercase">
-            Hours
-          </h4>
-          <p class="m-0 text-[#4a5568]">{{ space.openingHours }}</p>
+          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Hours</h4>
+          <p class="text-body m-0">{{ space.openingHours }}</p>
         </div>
 
         <!-- Update link for verified spaces -->
-        <div v-if="space.verified" class="mt-3 border-t border-[#e2d9c8] pt-3">
+        <div v-if="space.verified" class="border-warm mt-3 border-t pt-3">
           <a
             :href="updateUrl"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-xs text-[#718096] hover:text-[#ed8936] hover:underline"
+            class="text-muted hover:text-accent focus-visible:ring-accent rounded text-xs hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Something wrong? Update this space →
           </a>

--- a/src/components/SpaceList.vue
+++ b/src/components/SpaceList.vue
@@ -88,24 +88,24 @@ const filteredAndSortedSpaces = computed(() => {
     <!-- Empty state -->
     <div
       v-if="filteredAndSortedSpaces.length === 0"
-      class="rounded-lg border-2 border-dashed border-[#cbd5e0] bg-[#f5f0e6] px-6 py-12 text-center"
+      class="border-cool bg-cream-panel rounded-lg border-2 border-dashed px-6 py-12 text-center"
     >
       <template v-if="isOnlyOpenNowActive">
-        <p class="m-0 mb-2 text-lg text-[#718096]">Nothing open right now</p>
-        <p class="m-0 text-sm text-[#a0aec0]">
+        <p class="text-muted m-0 mb-2 text-lg">Nothing open right now</p>
+        <p class="text-faint m-0 text-sm">
           Leuven is quiet at this hour. Try turning off <strong>Open now</strong>, or check back
           later.
         </p>
       </template>
       <template v-else-if="props.filters.openNow">
-        <p class="m-0 mb-2 text-lg text-[#718096]">No open spaces match your filters</p>
-        <p class="m-0 text-sm text-[#a0aec0]">
+        <p class="text-muted m-0 mb-2 text-lg">No open spaces match your filters</p>
+        <p class="text-faint m-0 text-sm">
           Try removing <strong>Open now</strong> or loosening another filter.
         </p>
       </template>
       <template v-else>
-        <p class="m-0 mb-2 text-lg text-[#718096]">No spaces match your filters</p>
-        <p class="m-0 text-sm text-[#a0aec0]">Try adjusting your filter criteria</p>
+        <p class="text-muted m-0 mb-2 text-lg">No spaces match your filters</p>
+        <p class="text-faint m-0 text-sm">Try adjusting your filter criteria</p>
       </template>
     </div>
 

--- a/src/components/SpaceSummary.vue
+++ b/src/components/SpaceSummary.vue
@@ -113,8 +113,8 @@ function getNoiseStyle(level: string) {
         <h3
           :class="[
             compact
-              ? 'm-0 mb-1 text-lg font-bold text-[#1a365d]'
-              : 'font-display m-0 mb-1 text-xl font-bold text-[#1a365d]',
+              ? 'text-primary m-0 mb-1 text-lg font-bold'
+              : 'font-display text-primary m-0 mb-1 text-xl font-bold',
             visited && 'line-through opacity-70',
           ]"
         >
@@ -125,7 +125,7 @@ function getNoiseStyle(level: string) {
           :href="space.googleMapsUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="m-0 text-sm text-[#718096] hover:text-[#ed8936] hover:underline"
+          class="text-muted hover:text-accent focus-visible:ring-accent m-0 rounded text-sm hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           {{ space.address.split(',')[0] }}</a
         >
@@ -135,15 +135,15 @@ function getNoiseStyle(level: string) {
         <button
           @click="handleToggleVisited"
           v-tippy="visited ? 'Click to unmark' : 'Check off once you\'ve visited!'"
-          class="flex h-7 w-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-all duration-200"
+          class="focus-visible:ring-accent flex h-7 w-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           :class="
             visited
               ? 'border-green-500 bg-green-500 text-white'
-              : 'border-[#cbd5e0] bg-white text-transparent hover:border-[#ed8936] hover:text-[#ed8936]'
+              : 'border-cool hover:border-accent hover:text-accent bg-white text-transparent'
           "
         >
           <span
-            class="text-sm transition-transform duration-200"
+            class="text-sm transition-transform duration-200 motion-reduce:transition-none"
             :class="{ 'scale-125': justChecked }"
           >
             {{ visited ? '✓' : '○' }}
@@ -153,7 +153,7 @@ function getNoiseStyle(level: string) {
         <span
           v-if="!space.verified"
           v-tippy="VERIFIED_DESCRIPTIONS.unverified"
-          class="cursor-help text-xs font-medium text-[#ed8936]"
+          class="text-accent cursor-help text-xs font-medium"
         >
           ⚠️ Unverified
         </span>
@@ -177,7 +177,7 @@ function getNoiseStyle(level: string) {
         :href="verifyUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="font-semibold text-[#ed8936] hover:underline"
+        class="text-accent focus-visible:ring-accent rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         Help verify it →
       </a>
@@ -210,8 +210,8 @@ function getNoiseStyle(level: string) {
       <span
         v-tippy="SEATING_DESCRIPTIONS[space.seatingType]"
         :class="[
-          'cursor-help rounded bg-[#f5f0e6] px-2 text-xs font-medium text-[#1a365d]',
-          compact ? 'py-0.5' : 'border border-[#e2d9c8] py-1',
+          'bg-cream-panel text-primary cursor-help rounded px-2 text-xs font-medium',
+          compact ? 'py-0.5' : 'border-warm border py-1',
         ]"
       >
         🪑 {{ SEATING_LABELS[space.seatingType] }}
@@ -243,8 +243,8 @@ function getNoiseStyle(level: string) {
     </div>
 
     <!-- Description -->
-    <div v-if="space.description" class="mt-3 rounded bg-[#faf5eb] px-3 py-2">
-      <p class="m-0 text-sm text-[#4a5568] italic">"{{ space.description }}"</p>
+    <div v-if="space.description" class="bg-cream-deep mt-3 rounded px-3 py-2">
+      <p class="text-body m-0 text-sm italic">"{{ space.description }}"</p>
     </div>
 
     <!-- Unverified notice -->
@@ -258,7 +258,7 @@ function getNoiseStyle(level: string) {
         :href="verifyUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="ml-1 font-semibold text-[#ed8936] hover:underline"
+        class="text-accent focus-visible:ring-accent ml-1 rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         Help verify →
       </a>

--- a/src/components/TodayView.vue
+++ b/src/components/TodayView.vue
@@ -34,10 +34,10 @@ const picks = computed(() => getFeaturedSpaces(props.spaces))
 <template>
   <section v-if="picks.length > 0" class="mb-6" aria-label="Today's featured coworking spaces">
     <div class="mb-3 flex items-center justify-between">
-      <h2 class="font-display m-0 text-lg font-bold text-[#1a365d] sm:text-xl">Today's picks</h2>
+      <h2 class="font-display text-primary m-0 text-lg font-bold sm:text-xl">Today's picks</h2>
       <button
         type="button"
-        class="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-[#718096] transition-colors hover:text-[#1a365d] focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:outline-none"
+        class="text-muted hover:text-primary focus-visible:ring-accent flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
         :aria-expanded="!collapsed"
         :aria-label="collapsed ? 'Show today\'s picks' : 'Hide today\'s picks'"
         @click="collapsed = !collapsed"
@@ -45,7 +45,7 @@ const picks = computed(() => getFeaturedSpaces(props.spaces))
         <span>{{ collapsed ? 'Show' : 'Hide' }}</span>
         <span
           aria-hidden="true"
-          class="inline-block transition-transform"
+          class="inline-block transition-transform motion-reduce:transition-none"
           :class="{ 'rotate-180': !collapsed }"
         >
           ▼

--- a/src/components/VisitProgress.vue
+++ b/src/components/VisitProgress.vue
@@ -46,7 +46,7 @@ async function copyShareLink() {
   <Transition name="slide-up">
     <div
       v-if="visitedCount > 0"
-      class="fixed right-0 bottom-0 left-0 z-50 bg-[#1a365d] text-white shadow-lg"
+      class="bg-primary fixed right-0 bottom-0 left-0 z-50 text-white shadow-lg"
     >
       <div class="mx-auto max-w-6xl px-6 py-3">
         <div class="flex items-center justify-between gap-4">
@@ -56,11 +56,11 @@ async function copyShareLink() {
               <p class="m-0 text-sm font-medium">
                 {{ message }}
               </p>
-              <p class="m-0 text-xs text-[#cbd5e0]">
+              <p class="text-cool m-0 text-xs">
                 {{ visitedCount }} of {{ totalSpaces }} spaces visited ·
                 <button
                   v-tippy="'Bookmark this link to restore your progress'"
-                  class="cursor-pointer border-0 bg-transparent p-0 text-[#cbd5e0] underline transition-colors hover:text-white"
+                  class="text-cool focus-visible:ring-accent cursor-pointer rounded border-0 bg-transparent p-0 underline transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
                   :class="{ 'text-green-400 hover:text-green-400': copyStatus === 'copied' }"
                   @click="copyShareLink"
                 >
@@ -74,13 +74,13 @@ async function copyShareLink() {
 
           <!-- Progress bar -->
           <div class="flex min-w-0 flex-1 items-center gap-3">
-            <div class="h-3 flex-1 overflow-hidden rounded-full bg-[#2d4a7c]">
+            <div class="bg-primary-track h-3 flex-1 overflow-hidden rounded-full">
               <div
-                class="h-full rounded-full bg-[#ed8936] transition-all duration-500 ease-out"
+                class="bg-accent h-full rounded-full transition-all duration-500 ease-out motion-reduce:transition-none"
                 :style="{ width: `${percentage}%` }"
               />
             </div>
-            <span class="flex-shrink-0 text-xs text-[#cbd5e0]">{{ percentage }}%</span>
+            <span class="text-cool flex-shrink-0 text-xs">{{ percentage }}%</span>
           </div>
         </div>
       </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1,19 +1,33 @@
 @import 'tailwindcss';
 
-:root {
+@theme {
+  /* Brand */
   --color-primary: #1a365d;
-  --color-secondary: #2d3748;
+  --color-primary-hover: #15284a;
+  --color-primary-track: #2d4a7c;
   --color-accent: #ed8936;
-  --color-surface: #fffaf0;
-  --color-surface-dark: #faf5eb;
-  --color-text: #1a202c;
-  --color-text-muted: #718096;
+  --color-accent-hover: #dd7826;
+
+  /* Surfaces */
+  --color-cream: #fffaf0;
+  --color-cream-panel: #f5f0e6;
+  --color-cream-deep: #faf5eb;
+
+  /* Borders */
+  --color-warm: #e2d9c8;
+  --color-cool: #cbd5e0;
+
+  /* Text */
+  --color-ink: #1a202c;
+  --color-body: #4a5568;
+  --color-muted: #718096;
+  --color-faint: #a0aec0;
 }
 
 body {
   font-family: 'Crimson Pro', Georgia, serif;
-  background-color: var(--color-surface);
-  color: var(--color-text);
+  background-color: var(--color-cream);
+  color: var(--color-ink);
 }
 
 .font-display {

--- a/src/utils/askParser.ts
+++ b/src/utils/askParser.ts
@@ -233,8 +233,10 @@ function isWordBoundary(ch: string | undefined): boolean {
   return !ch || !/[a-z0-9]/.test(ch)
 }
 
+const MAX_QUERY_LENGTH = 1000
+
 export function parseAsk(query: string): IAskResult {
-  const normalized = query.toLowerCase()
+  const normalized = query.slice(0, MAX_QUERY_LENGTH).toLowerCase()
   const rawMatches: IRawMatch[] = []
 
   for (const entry of SORTED_PHRASES) {

--- a/tests/askParser.test.ts
+++ b/tests/askParser.test.ts
@@ -153,4 +153,12 @@ describe('parseAsk', () => {
     expect(r.matches[0].filter).toBe('wifiSpeed')
     expect(r.matches[0].value).toBe('fast')
   })
+
+  it('truncates pathologically long input to 1000 chars', () => {
+    const padding = 'x '.repeat(600) // ~1200 chars, beyond the cap
+    const beyondCap = parseAsk(`${padding}fast wifi`)
+    expect(beyondCap.matches).toHaveLength(0)
+    const beforeCap = parseAsk(`fast wifi ${padding}`)
+    expect(beforeCap.filterPatch).toEqual({ wifiSpeed: 'fast' })
+  })
 })


### PR DESCRIPTION
## Summary

Closes the actionable design-debt items from the prior session.

- **Theme tokens**: every `bg-[#hex]` / `text-[#hex]` / `border-[#hex]` bracket class across 11 components migrated to one of the 14 named Tailwind 4 `@theme` tokens defined in `src/style.css` (`primary`, `accent`, `cream`, `cream-panel`, `cream-deep`, `warm`, `cool`, `ink`, `body`, `muted`, `faint`, plus `primary-hover` / `accent-hover` / `primary-track`). One source of truth for colour, no more inline hex.
- **Focus rings**: every interactive control now carries `focus-visible:ring-2 focus-visible:ring-accent` (offset-2 except where the parent is `overflow-hidden`, which uses `ring-inset`). Covers FilterBar selects/sort/Clear, App-level Filter/View toggles + footer CTAs/text links, SpaceCard collapsible toggle, SpaceSummary visit-tick + Help-verify + address links, VisitProgress copy-link button, AskBar input.
- **Reduced motion**: every `transition-(colors|all|transform|opacity)` instance is paired with `motion-reduce:transition-none` so `prefers-reduced-motion` cuts animation to zero.
- **AskParser hardening**: defensive 1000-char input cap in `parseAsk()` against pathological queries that would scan SORTED_PHRASES (~140 entries) over a giant haystack. New test pinned to the boundary.
- **Docs**: TODOS.md gains Weekend 2 + Weekend 3 retros and marks debt items closed; DESIGN.md updated to reflect current state.

## Test plan

- [x] `npm run test` — 59 pass (3 files)
- [x] `npm run build` — vue-tsc + vite both green
- [x] `npm run format:check` — clean
- [ ] Manual spot-check at 375px and desktop: focus rings visible on Tab through every control
- [ ] Toggle `prefers-reduced-motion` in devtools → confirm transitions cut to zero
- [ ] Paste a >1000-char Ask query → no chips emitted, no UI lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)