### PR TITLE
:lipstick: Design tightening pass: editorial direction, Lucide icons, custom map pins

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,9 @@
 
 The canonical reference for visual language on Leuven Coworking Cafes. Keep this doc in sync when palette, type, or component-level conventions change.
 
-Brand mood: _neighbourhood cafe directory_, not tech product. Warm paper-cream backgrounds, navy for authority, orange for action. Serif body type for the "printed-guide" feel; emoji prefixes on interactive controls for a handmade voice.
+Brand mood: _neighbourhood cafe directory_, not tech product. Warm paper-cream backgrounds, navy for editorial display, **rust** for action and active state. Fraunces for display, Source Serif 4 italic for entry descriptions, IBM Plex Sans for UI chrome, IBM Plex Mono for date stamps and small data. Lucide icons replace emoji on UI metadata; emoji is reserved for the weather chip (where the glyph carries weather meaning).
+
+Page structure is two distinct sections. **Today's picks** is a discovery aid (3 daily-rotating cards that flip to reveal). **All spots** is the main content (filterable list, switchable to map). The List/Map toggle is a prominent segmented control attached to the All-spots header, not buried in the filter row. The footer ends with a single asymmetric marketing callout for the Leuven coworking group (the conversion CTA), plus a quiet inline contribution link.
 
 ## How to use this doc
 
@@ -16,42 +18,46 @@ Rules in this doc are **prescriptive** unless marked otherwise. Anything under "
 ## Contents
 
 1. [Palette](#palette) — brand / surfaces / text / semantic hues, with why each exists
-2. [Typography](#typography) — two faces, Tailwind scale, no custom ramp
+2. [Typography](#typography) — four families: Fraunces / Source Serif 4 / IBM Plex Sans / IBM Plex Mono
 3. [Layout & responsive](#layout--responsive) — breakpoints, container, grids, spacing
-4. [Component conventions](#component-conventions) — extending the system, iconography, variants, states, motion
+4. [Component conventions](#component-conventions) — extending the system, Lucide iconography, variants, states, motion, card shapes, toolbar layout
 5. [Accessibility baseline](#accessibility-baseline) — contrast pairs, aria patterns, keyboard, reduced motion
-6. [Open questions](#open-questions) — design forks we haven't picked yet
-7. [Design debt](#design-debt) — known gaps with a plan to close them
+6. [AskBar pattern](#askbar-pattern) — natural-language filter input
+7. [VisitProgress pattern](#visitprogress-pattern) — bottom bar, neutral count, share link
+8. [Marketing callout pattern](#marketing-callout-pattern) — coworking group conversion CTA
+9. [Map markers pattern](#map-markers-pattern) — custom rust pins, popup, mobile fullscreen
+10. [Open questions](#open-questions) — design forks we haven't picked yet
+11. [Design debt](#design-debt) — known gaps with a plan to close them
 
 ---
 
 ## Palette
 
-Scope is deliberately narrow: **two brand hues** (navy for authority, orange for action), **warm neutrals** for surfaces (cream + warm-grey borders), **cool greys** for text, and **Tailwind defaults** for status. Any new hex outside these four groups is a red flag — first ask whether an existing token covers it.
+Scope is deliberately narrow: **two brand hues** (navy for editorial display, rust for action), **warm neutrals** for surfaces (paper cream + warm rules), **cool greys** for text, **moss** as a single tertiary for the "verified recently" dot, and **Tailwind defaults** for status. Any new hex outside these groups is a red flag — first ask whether an existing token covers it.
 
 ### Brand
 
-_Why these two:_ navy reads as "editorial / guide," orange is the only true accent and is reserved for calls-to-action and active-state affordance. Don't introduce a secondary accent.
+_Why these two:_ navy reads as "editorial press / guide," rust is the only true accent and is reserved for active state, focus rings, calls-to-action, and the marketing callout border. The rust shift from `#ed8936` to `#c75f1c` was made to read less "Halloween candy / SaaS dashboard" and more "Leuven roof tiles / printed brick." Don't introduce a secondary accent.
 
 | Role           | Hex       | Used as                                                   |
 | -------------- | --------- | --------------------------------------------------------- |
-| Navy (primary) | `#1a365d` | Header bg, active controls, body headings, borders        |
-| Navy hover     | `#15284a` | Hover state on active navy buttons (OpenNowChip only)     |
-| Navy track     | `#2d4a7c` | Progress bar track behind the orange fill (VisitProgress) |
-| Orange         | `#ed8936` | CTA buttons, active-state accent, badges, focus rings     |
-| Orange hover   | `#dd7826` | Hover state on orange CTAs                                |
+| Navy (primary) | `#1a365d` | Page title, entry names, segmented-toggle active fill, popup borders, body headings |
+| Navy hover     | `#15284a` | Hover on filled navy controls (segmented toggle, OpenNowChip) |
+| Navy track     | `#2d4a7c` | Progress bar track behind the rust fill (legacy; VisitProgress now uses rule-soft) |
+| Rust (accent)  | `#c75f1c` | Active filter underlines, focus rings, marketing callout border + button, "Tip" label, slot labels on picks, tab/list active state, map pin |
+| Rust hover     | `#a64f10` | Hover on rust CTAs                                        |
+| Moss           | `#5C6B3C` | "Verified recently" dot next to entry names. Tertiary only — never on chrome. |
 
 ### Surfaces
 
 _Why warm neutrals:_ cream evokes printed-guide / book paper and separates us from the flat-white tech-product default. Never substitute a cool grey.
 
-| Role            | Hex       | Used as                                                          |
-| --------------- | --------- | ---------------------------------------------------------------- |
-| Cream (default) | `#fffaf0` | Page background                                                  |
-| Cream surface   | `#f5f0e6` | FilterBar panel, footer bg, card hover bg, map empty-state veil  |
-| Cream deep      | `#faf5eb` | Card quote-block bg (SpaceSummary description)                   |
-| Warm border     | `#e2d9c8` | SpaceCard border, footer top border, tag borders                 |
-| Cool border     | `#cbd5e0` | Form control borders, dashed empty-state border, header subtitle |
+| Role             | Hex       | Used as                                                                  |
+| ---------------- | --------- | ------------------------------------------------------------------------ |
+| Paper            | `#fffaf0` | Page background, VisitProgress bar bg, map popup bg, segmented toggle inactive bg |
+| Paper deep       | `#faf5eb` | Marketing callout background, list-row hover tint, FilterBar panel       |
+| Rule             | `#d8c9ad` | Section dividers, today's-picks card border, masthead bottom rule, marketing callout border (when not rust), VisitProgress top border |
+| Rule soft        | `#ede2cc` | Hairline between list entries, hairline above pills/flip-hint inside pick cards, `<hr>` decoration |
 
 ### Text
 
@@ -83,14 +89,20 @@ These match Tailwind 3 defaults (`green-500`, `yellow-500`, `red-500`, `gray-400
 
 ## Typography
 
-Loaded via Google Fonts link in `index.html`; declared in `src/style.css`.
+Four families, four roles. Loaded via Google Fonts link in `index.html`; declared as CSS custom properties in `src/style.css`. Each role is prescriptive — don't reach for a different family without running the "extending the system" test below.
 
-| Token        | Family                          | Weight | Where                                      |
-| ------------ | ------------------------------- | ------ | ------------------------------------------ |
-| Display      | `Playfair Display`, Georgia     | 700    | `.font-display` utility on `<h1>`, `<h2>`  |
-| Body (base)  | `Crimson Pro`, Georgia          | 400    | Applied globally via `body` rule           |
+| Token   | Family                                     | Weights        | Role                                                                                   |
+| ------- | ------------------------------------------ | -------------- | -------------------------------------------------------------------------------------- |
+| Display | `Fraunces`, Georgia, serif                 | 600, 700       | Page title, today's-pick names, list entry names, section headers (`<h2>`/`<h3>`)      |
+| Body    | `Source Serif 4`, Georgia, serif           | 400, italic 400 | Entry descriptions (italic), pick-card hooks (italic), empty-state title (italic), the `.num` in VisitProgress (italic). Default `<body>` font. |
+| UI      | `IBM Plex Sans`, system-ui, sans-serif     | 400, 500       | Filter tab labels, pill metadata, segmented toggle, button labels, footer copy, marketing CTA, AskBar prefix label, slot labels (small caps via `text-transform: uppercase` + `letter-spacing: 0.16em`). Picks the visual chrome of the directory. |
+| Mono    | `IBM Plex Mono`, ui-monospace, monospace   | 400, 500       | Last-visited stamps, footer data line ("47 cafés · last updated …"), "Leuven · centrum" map label, map list-item numbers, AskBar `or describe what you want` caption, color-swatch hex labels. Anything that should read as "data, not prose." |
 
-Scale is pure Tailwind (`text-xs`/`sm`/`base`/`lg`/`xl`/`2xl`/`4xl`/`5xl`). No custom type ramp. H1 in header scales `text-2xl sm:text-4xl md:text-5xl`.
+Scale is pure Tailwind (`text-xs`/`sm`/`base`/`lg`/`xl`/`2xl`/`4xl`/`5xl`). No custom type ramp. Page title scales `text-2xl sm:text-4xl md:text-5xl`. Today's-pick name is `text-2xl` (Fraunces 700). List entry name is `text-xl` (Fraunces 600).
+
+**Why these specifically.** Fraunces over Playfair Display: Playfair has converged on AI-design output as the default literary serif; Fraunces has more character (variable axes, optical sizing, soft-vs-sharp toggle) and reads less templated. Source Serif 4 over Crimson Pro for descriptions: Source Serif's italic carries the "field-guide footnote" voice; Crimson Pro's body felt magazine-y on a dense list. IBM Plex Sans for UI: the visual feel is "Belgian rail timetable / printed-guide caption" — utilitarian without being Inter-default. IBM Plex Mono for data: same family as the UI sans, so the visual rhythm carries.
+
+**Banned: `system-ui`/`-apple-system` as the primary display or body font.** It's the AI-design "I gave up on typography" signal.
 
 ---
 
@@ -126,44 +138,56 @@ Scale is pure Tailwind (`text-xs`/`sm`/`base`/`lg`/`xl`/`2xl`/`4xl`/`5xl`). No c
 
 These questions replace the bare "don't add a third radius without a reason" rule — they're what counts as a reason.
 
-**Iconography (emoji) policy.** Toolbar controls lead with a single emoji to signal function at a glance. Rules when picking one:
+**Iconography.** Lucide is the chosen library. All UI metadata icons (pills, filter tabs, segmented toggle, map marker references) use Lucide via inline SVG `<symbol>` definitions in `App.vue` (or a dedicated `IconSet.vue`), referenced by `<svg class="icon"><use href="#i-name"/></svg>`. Stroke width 1.6, `fill: none`, `stroke: currentColor` so icons inherit the surrounding text color. Default size 14×14 (`.icon`); 12×12 inside pills (`.icon-sm`).
 
-- One glyph per control. No combos.
-- **Literal over abstract** — `🗺️` for map, not `🌍`. `📋` for list, not `📝`. Prefer what the button *does*, not a metaphor.
-- No flags, no skin-tone modifiers, no gendered glyphs.
-- Reserved-meaning glyphs: ☀️/⛅/🌧️/❄️/🌫️ mean "weather-driven UI state" — don't reuse them for non-weather controls.
-- If no emoji feels right, don't force one — leave the label alone rather than ship something off-brand.
+Why Lucide over emoji on UI chrome: emoji rendered platform-by-platform vary in weight, color and metaphor (Apple's 🎛️ is not Google's 🎛️). Mixing eight emoji prefixes is the loudest "AI-built" visual signal we ship. Lucide gives one consistent stroke, one consistent metaphor, one consistent color.
 
-Current inventory:
+Inventory (codify before adding new):
 
-| Control         | Glyph  |
-| --------------- | ------ |
-| Filters toggle  | 🎛️     |
-| List view       | 📋     |
-| Map view        | 🗺️     |
-| Open now chip   | ☀️ / ⛅ / 🌧️ / ❄️ / 🌫️ / ⏳ / ⏰ (weather-driven) |
+| Symbol id        | Where                                                        |
+| ---------------- | ------------------------------------------------------------ |
+| `i-sun`          | "Open now" filter tab                                        |
+| `i-moon`         | "Late" filter tab                                            |
+| `i-volume-quiet` | Quiet noise level (filter tab + entry meta + pick pill)      |
+| `i-volume-mid`   | Moderate noise level                                         |
+| `i-volume-loud`  | Buzzy noise level                                            |
+| `i-wifi`         | Wifi speed (filter tab + entry meta + pick pill)             |
+| `i-plug`         | Outlets (filter tab + entry meta + pick pill)                |
+| `i-snowflake`    | AC (in entry meta where present)                             |
+| `i-utensils`     | Food / drinks (entry meta + pick pill)                       |
+| `i-armchair`     | Seating type (entry meta where used)                         |
+| `i-clock`        | Open / closed status text in entry meta                      |
+| `i-list`         | List view in segmented toggle                                |
+| `i-map-pin`      | Map view in segmented toggle, map markers (in CSS), Today's-pick city label |
+| `i-check`        | VisitProgress count icon                                     |
 
-Keep this convention for any new toolbar control — it's the main visual personality of the header.
+**Emoji is reserved for the weather chip only.** ☀️/⛅/🌧️/❄️/🌫️/⏳/⏰ on `OpenNowChip` are weather-driven UI state — the glyph carries the meaning. Everywhere else, use Lucide. If no Lucide icon fits, ship the label alone rather than reach for an emoji.
 
 **Touch targets.** Controls that can be tapped on mobile use `min-h-[44px]` (Apple HIG). Toolbar buttons currently inherit enough padding; OpenNowChip enforces it explicitly — do the same for any new chip.
 
-**Button shape & padding.** Three recipes in use:
+**Button & control shapes.** The system is now sharp-cornered. **Default radius is 0.** The previous `rounded-lg border-2` everywhere was the loudest "AI-bubbly" shape signal in the old design. Recipes now in use:
 
-| Role                                 | Classes                                                           |
-| ------------------------------------ | ----------------------------------------------------------------- |
-| Primary toolbar chip (Filters, OpenNow) | `rounded-lg border-2 px-3 py-2 text-sm font-medium`               |
-| Segmented toggle (List / Map)        | `rounded-lg border-2 px-4 py-2 text-sm font-medium` on the wrapper, inner `px-4 py-2` per segment |
-| Inline tag / tertiary                | `rounded` (4px radius), padding scales with context               |
+| Role                                  | Shape                                                                      |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| Filter tab (text + Lucide icon)       | No box — text only, with a 2px rust underline on `aria-selected="true"`. Padding `px-3 py-2`. Hairline `1px` rule on either side via flexbox dividers. |
+| Segmented toggle (List / Map)         | Sharp-cornered inflex container, 1px navy border. Inner segments share a 1px navy left-divider. Active segment fills navy with paper text. Inactive is white bg. Padding `px-4 py-2`. |
+| Marketing CTA button (rust)           | Sharp-cornered, 1px rust border, rust fill, paper text. Padding `px-4 py-2.5`. Hover darkens to `--rust-hover`. Inline-flex with arrow icon at 16px. |
+| AskBar input                          | No box. 1.5px rule underline (turns rust on focus-within). No padding-x. Padding `pt-1 pb-2.5`. |
+| List entry (in `<SpaceList>`)         | No box. Hairline `1px` `--rule-soft` border-bottom between rows. `py-5`. Hover tints background `rgba(199,95,28,0.025)`. |
+| Today's-pick card                     | 1px `--rule` border (no `rounded-lg`). Hover swaps border to rust. Photo on top (desktop) or left (mobile). |
+| Marketing callout                     | 1px rust border. Asymmetric grid (photo + body). "A Note" tag in rust ribbon at top-right. |
+| OpenNowChip / VisitProgress share link | Quiet text with rust underline. Sharp corners on any container. |
 
-Don't introduce a third radius without running the "extending the system" test above.
+The only places radius appears at all: the moss/rust circles for "verified" dots and map pins (`border-radius: 50%`). Otherwise the page is rules-and-rectangles.
 
-**Button variants.** Three variants in use — keep to these:
+**Button variants.** Four variants — keep to these:
 
-| Variant    | Default                                           | Active / pressed                                  | Hover                          |
-| ---------- | ------------------------------------------------- | ------------------------------------------------- | ------------------------------ |
-| Navy chip  | `border-[#1a365d] bg-white text-[#1a365d]`        | `border-[#1a365d] bg-[#1a365d] text-white`        | `hover:bg-[#f5f0e6]` (inactive) / `hover:bg-[#15284a]` (active) |
-| Orange CTA | `bg-[#ed8936] text-white` (no border)             | n/a (CTAs don't toggle)                           | `hover:bg-[#dd7826]`           |
-| Ghost      | `bg-white text-[#1a365d]` (no border)             | n/a                                               | `hover:bg-[#f5f0e6]`           |
+| Variant            | Default                                         | Active / pressed                                  | Hover                                |
+| ------------------ | ----------------------------------------------- | ------------------------------------------------- | ------------------------------------ |
+| Filter tab         | `text-muted bg-transparent`, no border          | `text-ink border-b-2 border-rust font-medium`     | `text-ink`                           |
+| Segmented seg      | `bg-white text-ink border-l border-navy` (or `border-y`/`border-r` for endcaps) | `bg-navy text-paper`                              | `bg-paper-deep` (when not active)    |
+| Rust CTA (marketing) | `bg-rust border-rust text-paper`              | n/a                                               | `bg-rust-hover border-rust-hover`    |
+| Quiet text link    | `text-ink border-b border-rust`                 | n/a                                               | `text-rust`                          |
 
 **Interactive states.** All clickable elements handle these five states (not all apply to every control):
 
@@ -173,7 +197,7 @@ Don't introduce a third radius without running the "extending the system" test a
 - **Focus** — orange ring (see below). Mandatory, never `outline-none` without replacement.
 - **Disabled / loading** — `disabled:opacity-60 disabled:cursor-not-allowed` and/or a loading label prefix (see OpenNowChip's `⏳` state). Spinners are not in the system — use an emoji or text cue.
 
-**Focus.** Active focus ring is orange: `focus-visible:ring-2 focus-visible:ring-[#ed8936] focus-visible:ring-offset-2 focus-visible:outline-none`. Use this pattern on all new interactive elements, not the browser default.
+**Focus.** Active focus ring is rust: `focus-visible:ring-2 focus-visible:ring-rust focus-visible:ring-offset-2 focus-visible:outline-none`. Use this pattern on all new interactive elements, not the browser default. Tab targets that already use a rust underline as their active state still get a focus ring (offset keeps the ring legible against the underline).
 
 **Motion.** Three tokens, and no more:
 
@@ -185,12 +209,21 @@ Don't introduce a third radius without running the "extending the system" test a
 
 No `transform` transitions, no `scale`/`translate` on hover, no new easing curves. The paper-guide mood means motion is subtle and functional — never decorative.
 
-**Card shape.** `rounded-lg border-2 border-[#e2d9c8]` on a white bg.
-- **Default** — cream border, no shadow.
-- **Hover** — border swaps to `#ed8936` (orange), `shadow-lg` lifts the card. Driven by `transition-all duration-200` (see Motion).
-- No focus state on cards themselves — interactive elements *inside* cards carry the focus ring instead.
+**Card shape.** Three card shapes, prescriptive:
 
-**Toolbar layout.** Horizontal controls use `flex flex-wrap items-center gap-2 sm:gap-3` so the toolbar wraps cleanly at 375px without horizontal scroll. Any new toolbar control should inherit this — don't add `flex-nowrap`.
+1. **List entry** (`<SpaceCard>` in the All-spots list). NOT a card — a row. No border, no rounded corners, no shadow. `border-bottom: 1px solid var(--color-rule-soft)`. Padding `py-5`. Two-column grid on desktop (88px photo + content + right-aligned mono date stamp); two-column on mobile (64px photo + content; date stamp moves to a third row with a dashed-rule top).
+2. **Today's-pick card** (`<FeaturedCard>`). 1px `--color-rule` solid border. Sharp corners. Photo strip on top (130px desktop) → `<body>` with slot label / name / hook / description / pills / flip-hint. Hover swaps border to rust. Mobile: grid-cols-`92px 1fr`, photo on left, body shrinks (description + hook hidden).
+3. **Marketing callout** (`<CoworkingGroupCallout>`). 1px rust border, `--color-paper-deep` bg. Asymmetric grid: photo (280px desktop) + body. "A Note" rust ribbon at top-right. Body has eyebrow / Fraunces headline (700 + italic em on a phrase) / Source Serif description / rust CTA button row. Mobile stacks photo on top.
+
+No focus state on the cards themselves — interactive elements *inside* cards carry the focus ring instead.
+
+**Toolbar layout.** The header is now a multi-row composition:
+
+- **Section header row** for "All spots": `flex items-baseline justify-between` with the `<h2>All spots <span class="count">47</span></h2>` on the left and the `<view-segmented>` toggle on the right. On mobile (≤700px), `flex-direction: column-reverse` so the segmented toggle sits full-width above the heading.
+- **Filter tabs row**: `flex flex-wrap items-center gap-0` with text-tab buttons separated by hairline divider spans. No `flex-nowrap`.
+- **AskBar row**: stacked. `<label class="ask-label">` on top in mono; underlined `<input>` below; matched-chips row below the input when there are matches.
+
+The Today's-picks header is a separate, subordinate composition: italic Fraunces 600 `<h2>Today's picks</h2>` + mono `picks-meta` ("3 of 47 · rotates daily") on the right. Visually distinct from the main section header so users don't conflate the daily picks with the filterable list.
 
 ---
 
@@ -200,11 +233,12 @@ No `transform` transitions, no `scale`/`translate` on hover, no new easing curve
 
 | Pair                             | Use                                | Status                                           |
 | -------------------------------- | ---------------------------------- | ------------------------------------------------ |
-| Navy `#1a365d` on white          | Headings, body on cards            | AA / AAA                                         |
-| White on navy `#1a365d`          | Header, filled toggle buttons      | AA / AAA                                         |
-| Orange `#ed8936` on white        | CTA bg fill, focus ring            | AA for 14px+ bold and all 18px+                  |
-| Body muted `#4a5568` on cream    | Card body copy                     | AA                                               |
-| Orange `#ed8936` on cream `#f5f0e6` | **Accents only**                | Borderline — fails AA for body-sized text. Never for paragraphs. |
+| Navy `#1a365d` on paper          | Page title, entry names, popup borders | AA / AAA                                       |
+| Paper on navy `#1a365d`          | Filled segmented-toggle, OpenNowChip active | AA / AAA                                  |
+| Rust `#c75f1c` on paper          | CTA bg fill, focus ring, "Tip" label, slot labels | AA at 14px+ regular and all 16px+ (the rust shift from #ed8936 improved contrast — paper text on rust now passes at body sizes) |
+| Paper on rust                    | Marketing CTA button text          | AA / AAA                                         |
+| Body muted `#4a5568` on paper    | Card body copy, list-entry desc    | AA                                               |
+| Moss `#5C6B3C` 7px dot on paper  | Verified-recently dot              | Decoration only, not text. AA equivalent N/A.    |
 
 **Screen reader patterns.**
 
@@ -221,21 +255,70 @@ No `transform` transitions, no `scale`/`translate` on hover, no new easing curve
 
 ---
 
+## AskBar pattern
+
+Natural-language input that maps phrases to filter state via the regex parser in `src/utils/askParser.ts`. Visual contract:
+
+- Small mono caption above the input: `or describe what you want` (lowercase, `IBM Plex Mono` 10px, letter-spacing `0.08em`, `text-faint`). Caption sits on its own line so it can never wrap into the input.
+- Input is borderless except for a 1.5px `--rule` underline that turns rust on `:focus-within`.
+- Placeholder is **rotating** through the existing `EXAMPLES` array every 4s (preserved from the old AskBar). Cycle stops while the input has a value.
+- Empty input shows just the underline. As the parser matches, a `Matched` row appears below in `IBM Plex Sans` 12px with rust-underlined text-buttons (each is removable; click → strips the matched phrase from the input).
+- **No sparkle, no bouncing dots, no "Thinking..." animation.** The parser is fast enough that you don't need to dramatize the wait. If a future parse is genuinely slow, replace with a single quiet mono caption (`Checking the guide…`), not a dots-bounce.
+
+## VisitProgress pattern
+
+Sticky bottom bar that appears once a user has marked any space visited. Visual contract:
+
+- Background `--paper`, 1px `--rule` top border (NOT navy — the navy bar from the old design read as dashboard chrome).
+- Layout: rust `i-check` icon → `<span class="vp-text">` (Fraunces italic 600 16px count + Plex Sans "of 47 visited" muted) → 3px tall `--rule-soft` progress rule with rust fill → mono percentage right-aligned → rust-underlined "copy progress link" share action.
+- **Copy is neutral.** No "True coworking champion!", no "🎉 You're a Leuven coworking pro! 🌟", no trophy/checkmark emoji. Just the count and the share. Gamification copy was the loudest AI tell on the old VisitProgress; resist re-adding.
+- Mobile: `flex-wrap`, the progress rule moves to its own row below the count + percentage + share link.
+
+## Marketing callout pattern
+
+The Leuven coworking group invitation. **Site-wide single instance.** Renders between the All-spots list and the footer, NOT in the footer itself. Visual contract:
+
+- Asymmetric grid: 280px photo on the left, body on the right (mobile stacks photo on top).
+- 1px rust border. `--paper-deep` background to differentiate from the page paper.
+- "A Note" tag in a rust ribbon at top-right (Plex Sans 9.5px tracked uppercase paper text on rust fill, 4px×10px padding).
+- Eyebrow: Plex Sans 10px tracked uppercase rust ("Leuven coworking group").
+- Headline: Fraunces 700 28px navy, with one italicized phrase (e.g. *"Working with people is better."*) for emphasis without using bold or a second color.
+- Body: Source Serif 4 15px on `--ink`, max 460px wide.
+- CTA row: rust-filled button (`Join the group →` with Lucide arrow at 16px / stroke 2) + mono URL caption to its right.
+
+The ribbon + asymmetric layout makes this visually distinct from list rows and from the footer, which is the point — the site is a marketing funnel for the coworking group, and the conversion CTA needs to be findable. Symmetric dual-card footers are the AI-default and bury the conversion next to the contribution.
+
+## Map markers pattern
+
+Custom Leaflet markers (replacing the default blue droplets). Implementation: `L.divIcon` with HTML, or SVG marker classes, styled with these tokens.
+
+| Marker          | Treatment                                                                     |
+| --------------- | ------------------------------------------------------------------------------ |
+| Default pin     | 22×22 circle. `bg-rust`, 2px `--paper` border, 6×6 paper dot center, soft drop shadow `0 1px 3px rgba(0,0,0,0.25)`. |
+| Active pin      | 28×28 same circle + 3px outer rust ring `box-shadow: 0 0 0 3px rgba(199,95,28,0.25)`. |
+| Cluster pin     | 34×34 same shape, count rendered inside in Plex Sans 600 11px paper. No center dot. |
+| Popup           | 1px navy hairline border, paper bg, navy diamond pointer at the bottom. Inside: mono "NN · Name" (rust caption), Fraunces 600 17px navy name, mono small-caps meta strip, rust-underlined "Show details →" link. |
+| Tile layer      | Light grayscale OSM (or Stadia Stamen Toner Lite). Avoid color-saturated default OSM tiles — they fight the cream paper feel. |
+
+Mobile: list panel hidden (`display: none`), the map takes `min-height: 460px` and `height: 70vh`. Spec also: a bottom sheet pattern for the selected pin's details on mobile (defer until building).
+
 ## Open questions
 
 Design forks the project hasn't resolved. Not debt (debt has a plan) — these are genuine choices waiting for the situation that forces them.
 
-- **Secondary accent colour.** Today orange is the only accent. If we ever need "info" or "neutral emphasis" that isn't a status signal, do we add a third brand hue or push harder on typography/weight? Push on type first.
-- **Map marker styling.** `MapView.vue` uses Leaflet default markers. They don't match the palette. Options: (a) custom orange pin, (b) small cafe-emoji marker, (c) leave default until the map becomes a core surface. Currently (c).
-- **Metadata icons vs. emoji policy.** `SpaceSummary` shows coloured dots and wifi-speed indicators — these are _semantic indicators_, not the emoji-button iconography. The doc's emoji policy doesn't apply to them. If we ever add true inline icons (Lucide / Heroicons), they'd be a new iconography category. Decide the icon library before shipping the first one.
-- **Copy voice.** The brand mood paragraph implies a "printed-guide" voice but there's no rubric (sentence length, formality, Oxford comma, you-vs-we). Empty-state copy in `SpaceList.vue` has one style; the footer has another. Tolerable for now; codify if the surface area grows.
-- **Dark mode.** Cross-referenced in Design debt. Open question: is cream-first identity still recognisable in dark mode, or does it need a full re-skin? Defer until user demand.
+- **Photos per space.** The new design includes photo placeholders on Today's-pick cards and entry rows. Real photos require either (a) adding an `imageUrl` field to `ICoworkingSpace` and sourcing photos manually, (b) generating deterministic gradient placeholders from the space name (current preview behavior), or (c) using a single hand-photo per neighbourhood as a fallback. Decide before shipping the new card layout.
+- **Map mobile bottom-sheet.** When a user taps a map pin on mobile, do we open a full-screen popup, a bottom sheet (~40% height), or transition to the entry's section in the list view? Bottom sheet feels right; defer until building.
+- **Copy voice rubric.** The brand mood implies a "field-guide" voice but there's still no rubric (sentence length, you-vs-we, oxford comma, capitalization of meta strips). The new design depersonalizes (`I → no first person`, `Pez's note → Tip`, neutral footer stamp). Codify the rubric before the surface area grows further.
+- **Dark mode.** Open question: is cream-first identity still recognisable in dark mode, or does it need a full re-skin? Defer until user demand.
 
 ---
 
 ## Design debt
 
-- ~~**CSS custom properties in `style.css` are unused.**~~ Resolved. `style.css` now declares Tailwind 4 `@theme` tokens (`primary`, `primary-hover`, `primary-track`, `accent`, `accent-hover`, `cream`, `cream-panel`, `cream-deep`, `warm`, `cool`, `ink`, `body`, `muted`, `faint`). Components use `bg-primary`, `text-accent`, `border-warm`, etc. No more `[#hex]` bracket classes anywhere in `src/`.
-- ~~**No `prefers-reduced-motion` handling.**~~ Resolved. Every `transition-(colors|all|transform|opacity)` utility is paired with `motion-reduce:transition-none`. The bouncing dots in `AskBar` use `motion-reduce:animate-none`.
-- ~~**Focus-ring rule not universally applied.**~~ Resolved. The prescribed `focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:outline-none` pattern is applied to every interactive element. Two known exceptions, both deliberate: (a) controls inside the segmented View toggle use `focus-visible:ring-inset` because the parent is `overflow-hidden`; (b) chip-internal controls in `AskBar` (the × on each match chip and the absolute-positioned Clear button) omit `ring-offset-2` because the offset would extend beyond the chip pill.
+- ~~**CSS custom properties in `style.css` are unused.**~~ Resolved. `style.css` now declares Tailwind 4 `@theme` tokens. Components use `bg-paper`, `text-rust`, `border-rule`, etc. No more `[#hex]` bracket classes anywhere in `src/`.
+- ~~**No `prefers-reduced-motion` handling.**~~ Resolved. Every `transition-(colors|all|transform|opacity)` utility is paired with `motion-reduce:transition-none`. The bouncing dots in `AskBar` are gone (replaced with rotating placeholder); placeholder rotation respects `prefers-reduced-motion: reduce` by pausing the cycle.
+- ~~**Focus-ring rule not universally applied.**~~ Resolved. The prescribed `focus-visible:ring-2 focus-visible:ring-rust focus-visible:ring-offset-2 focus-visible:outline-none` pattern is applied to every interactive element. Two known exceptions, both deliberate: (a) `seg` buttons inside the segmented View toggle use `focus-visible:ring-inset`; (b) the rust-underline tab style relies on the underline + offset for focus visibility (the ring offset keeps both legible).
+- **Tailwind token rename migration.** This redesign renames `accent → rust`, `primary → navy`, `warm → rule`, `cream → paper`, etc. After implementation, audit `src/` for any remaining `bg-accent`, `text-primary`, `border-warm` classes and update. Bracket classes (`[#ed8936]`, `[#1a365d]`) are forbidden by the existing rule and should already be absent — verify.
+- **Photos.** The new layout reserves space for cafe photos on Today's-pick cards and (optionally) entry rows. Until photos are sourced, both fall back to a deterministic neutral gradient. Track the gap.
+- **Map markers in MapView.vue still use Leaflet defaults.** Migration to custom rust pins (per the Map markers pattern above) is part of this redesign rollout.
 - **No dark mode.** Cream-first palette doesn't currently map to a dark counterpart. Defer until there's a user ask.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Leuven Coworking Cafes</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Playfair+Display:wght@600;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,400;1,9..144,700&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;1,400&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import VisitProgress from './components/VisitProgress.vue'
 import OpenNowChip from './components/OpenNowChip.vue'
 import TodayView from './components/TodayView.vue'
 import AskBar from './components/AskBar.vue'
+import IconDefs from './components/IconDefs.vue'
 import { parseOpeningHours, isOpen } from './utils/hoursBasic'
 import spacesData from './data/spaces.json'
 
@@ -114,6 +115,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 </script>
 
 <template>
+  <IconDefs />
   <div class="bg-paper min-h-screen">
     <!-- Header -->
     <header class="bg-navy px-4 py-6 text-white sm:px-6 sm:py-8">

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,9 +114,9 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 </script>
 
 <template>
-  <div class="bg-cream min-h-screen">
+  <div class="bg-paper min-h-screen">
     <!-- Header -->
-    <header class="bg-primary px-4 py-6 text-white sm:px-6 sm:py-8">
+    <header class="bg-navy px-4 py-6 text-white sm:px-6 sm:py-8">
       <div class="mx-auto flex max-w-6xl items-center gap-4 sm:gap-6">
         <img
           src="/favicon.svg"
@@ -127,7 +127,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
           <h1 class="font-display m-0 mb-1 text-2xl font-bold sm:mb-2 sm:text-4xl md:text-5xl">
             Leuven Coworking Cafes
           </h1>
-          <p class="text-cool m-0 text-sm sm:text-lg">Find your perfect spot to work in Leuven</p>
+          <p class="text-faint m-0 text-sm sm:text-lg">Find your perfect spot to work in Leuven</p>
         </div>
       </div>
     </header>
@@ -152,11 +152,11 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 
           <!-- Filter Toggle -->
           <button
-            class="focus-visible:ring-accent flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+            class="focus-visible:ring-rust flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
             :class="
               showFilters
-                ? 'border-primary bg-primary text-white'
-                : 'border-primary text-primary hover:bg-cream-panel bg-white'
+                ? 'border-navy bg-navy text-white'
+                : 'border-navy text-navy hover:bg-paper-deep bg-white'
             "
             @click="showFilters = !showFilters"
           >
@@ -164,31 +164,31 @@ function applyAskPatch(patch: Partial<IFilterState>) {
             <span
               v-if="activeFilterCount > 0"
               class="rounded-full px-1.5 py-0.5 text-xs font-bold"
-              :class="showFilters ? 'bg-accent text-white' : 'bg-accent text-white'"
+              :class="showFilters ? 'bg-rust text-white' : 'bg-rust text-white'"
             >
               {{ activeFilterCount }}
             </span>
           </button>
 
           <!-- View Mode Toggle -->
-          <div class="border-primary inline-flex overflow-hidden rounded-lg border-2">
+          <div class="border-navy inline-flex overflow-hidden rounded-lg border-2">
             <button
-              class="focus-visible:ring-accent px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
+              class="focus-visible:ring-rust px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
               :class="
                 viewMode === 'list'
-                  ? 'bg-primary text-white'
-                  : 'text-primary hover:bg-cream-panel bg-white'
+                  ? 'bg-navy text-white'
+                  : 'text-navy hover:bg-paper-deep bg-white'
               "
               @click="viewMode = 'list'"
             >
               📋 List
             </button>
             <button
-              class="border-primary focus-visible:ring-accent border-l-2 px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
+              class="border-navy focus-visible:ring-rust border-l-2 px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
               :class="
                 viewMode === 'map'
-                  ? 'bg-primary text-white'
-                  : 'text-primary hover:bg-cream-panel bg-white'
+                  ? 'bg-navy text-white'
+                  : 'text-navy hover:bg-paper-deep bg-white'
               "
               @click="viewMode = 'map'"
             >
@@ -215,18 +215,18 @@ function applyAskPatch(patch: Partial<IFilterState>) {
     </main>
 
     <!-- Footer -->
-    <footer class="border-warm bg-cream-panel mt-12 border-t-2 px-6 py-8 pb-24">
+    <footer class="border-rule bg-paper-deep mt-12 border-t-2 px-6 py-8 pb-24">
       <div class="mx-auto max-w-6xl space-y-6 text-center">
         <div class="flex flex-col justify-center gap-2 sm:flex-row">
-          <div class="bg-primary w-full rounded-lg p-6 text-white sm:w-auto sm:max-w-md sm:flex-1">
+          <div class="bg-navy w-full rounded-lg p-6 text-white sm:w-auto sm:max-w-md sm:flex-1">
             <p class="m-0 mb-3 text-lg font-medium">🏢 Know a great coworking spot?</p>
-            <p class="text-cool m-0 mb-4 text-sm">Help fellow remote workers find new places!</p>
+            <p class="text-faint m-0 mb-4 text-sm">Help fellow remote workers find new places!</p>
             <div class="flex flex-wrap justify-center gap-3">
               <a
                 :href="NEW_SPACE_URL"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="bg-accent hover:bg-accent-hover focus-visible:ring-accent rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+                class="bg-rust hover:bg-rust-hover focus-visible:ring-rust rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
               >
                 ✨ Suggest via GitHub
               </a>
@@ -234,16 +234,16 @@ function applyAskPatch(patch: Partial<IFilterState>) {
                 href="https://pezcuckow.com"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-primary hover:bg-cream-panel focus-visible:ring-accent rounded bg-white px-4 py-2 text-sm font-semibold no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+                class="text-navy hover:bg-paper-deep focus-visible:ring-rust rounded bg-white px-4 py-2 text-sm font-semibold no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
               >
                 ✉️ Email me
               </a>
             </div>
           </div>
           <div
-            class="border-accent w-full rounded-lg border-2 bg-white p-6 sm:w-auto sm:max-w-md sm:flex-1"
+            class="border-rust w-full rounded-lg border-2 bg-white p-6 sm:w-auto sm:max-w-md sm:flex-1"
           >
-            <p class="text-primary m-0 mb-2 text-lg font-medium">
+            <p class="text-navy m-0 mb-2 text-lg font-medium">
               👋 Looking for people to co-work with?
             </p>
             <p class="text-muted m-0 mb-4 text-sm">
@@ -253,7 +253,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
               href="https://labs.pez.io/leuven-social-groups/"
               target="_blank"
               rel="noopener noreferrer"
-              class="bg-accent hover:bg-accent-hover focus-visible:ring-accent inline-block rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+              class="bg-rust hover:bg-rust-hover focus-visible:ring-rust inline-block rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
             >
               Learn more →
             </a>
@@ -265,7 +265,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
             href="https://pezcuckow.com"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-muted hover:text-accent focus-visible:ring-accent rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            class="text-muted hover:text-rust focus-visible:ring-rust rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Pez
           </a>
@@ -274,7 +274,7 @@ function applyAskPatch(patch: Partial<IFilterState>) {
             href="https://github.com/Pezmc/coworking-spaces"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-muted hover:text-accent focus-visible:ring-accent rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            class="text-muted hover:text-rust focus-visible:ring-rust rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Open Source
           </a>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,6 @@
 import { ref, computed, watch } from 'vue'
 import { useUrlSearchParams } from '@vueuse/core'
 import type { ICoworkingSpace, IFilterState, ISortState } from './types/space'
-import { NEW_SPACE_URL } from './utils/issueUrl'
 import FilterBar from './components/FilterBar.vue'
 import SpaceList from './components/SpaceList.vue'
 import MapView from './components/MapView.vue'
@@ -11,6 +10,9 @@ import OpenNowChip from './components/OpenNowChip.vue'
 import TodayView from './components/TodayView.vue'
 import AskBar from './components/AskBar.vue'
 import IconDefs from './components/IconDefs.vue'
+import ViewSegmented from './components/ViewSegmented.vue'
+import CoworkingGroupCallout from './components/CoworkingGroupCallout.vue'
+import SiteFooter from './components/SiteFooter.vue'
 import { parseOpeningHours, isOpen } from './utils/hoursBasic'
 import spacesData from './data/spaces.json'
 
@@ -27,7 +29,6 @@ const DEFAULT_FILTERS: IFilterState = {
   openNow: false,
 }
 
-// URL params and filter states
 const urlParams = useUrlSearchParams<Record<string, string>>('history')
 const filters = ref<IFilterState>({
   noiseLevel: (urlParams.noiseLevel as IFilterState['noiseLevel']) || DEFAULT_FILTERS.noiseLevel,
@@ -43,7 +44,6 @@ const filters = ref<IFilterState>({
   openNow: urlParams.openNow === '1',
 })
 
-// Sync filters to URL
 watch(
   filters,
   (newFilters) => {
@@ -117,90 +117,65 @@ function applyAskPatch(patch: Partial<IFilterState>) {
 <template>
   <IconDefs />
   <div class="bg-paper min-h-screen">
-    <!-- Header -->
-    <header class="bg-navy px-4 py-6 text-white sm:px-6 sm:py-8">
-      <div class="mx-auto flex max-w-6xl items-center gap-4 sm:gap-6">
-        <img
-          src="/favicon.svg"
-          alt="Leuven Coworking Cafes logo"
-          class="h-12 w-12 flex-shrink-0 rounded-full bg-white p-1.5 sm:h-16 sm:w-16 md:h-20 md:w-20"
-        />
-        <div>
-          <h1 class="font-display m-0 mb-1 text-2xl font-bold sm:mb-2 sm:text-4xl md:text-5xl">
-            Leuven Coworking Cafes
-          </h1>
-          <p class="text-faint m-0 text-sm sm:text-lg">Find your perfect spot to work in Leuven</p>
-        </div>
-      </div>
-    </header>
+    <main class="mx-auto max-w-6xl px-5 pt-8 pb-8 sm:px-6 sm:pt-12">
+      <!-- Masthead -->
+      <header
+        class="border-rule mb-8 flex flex-col items-baseline justify-between gap-3 border-b pb-5 sm:flex-row sm:gap-8 sm:pb-7"
+      >
+        <h1
+          class="font-display text-navy m-0 text-3xl font-bold leading-[1.05] tracking-tight sm:text-4xl md:text-5xl"
+        >
+          Leuven Coworking Cafes
+        </h1>
+        <p
+          class="font-desc text-muted m-0 max-w-md text-sm leading-snug sm:text-right sm:text-base"
+        >
+          A small Leuven field guide to cafés where it's nice to open a laptop.
+        </p>
+      </header>
 
-    <!-- Main Content -->
-    <main class="mx-auto max-w-6xl px-6 py-8">
-      <!-- Today's picks (list view only) -->
+      <!-- Today's picks: standalone subordinate section, list view only -->
       <TodayView v-if="viewMode === 'list'" :spaces="spaces" />
 
-      <!-- Smart search: natural-language filter -->
-      <AskBar @apply="applyAskPatch" />
-
-      <!-- Toolbar: Space count, Filter toggle, View mode -->
-      <div class="mb-4 flex flex-wrap items-center justify-between gap-y-3">
-        <p class="text-muted m-0 text-sm">
-          Showing {{ filteredSpaces.length }} of {{ spaces.length }} spaces
-        </p>
-
-        <div class="flex flex-wrap items-center gap-2 sm:gap-3">
-          <!-- Open now chip -->
-          <OpenNowChip :active="filters.openNow" @toggle="toggleOpenNow" />
-
-          <!-- Filter Toggle -->
-          <button
-            class="focus-visible:ring-rust flex items-center gap-2 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-            :class="
-              showFilters
-                ? 'border-navy bg-navy text-white'
-                : 'border-navy text-navy hover:bg-paper-deep bg-white'
-            "
-            @click="showFilters = !showFilters"
-          >
-            🎛️ Filters
-            <span
-              v-if="activeFilterCount > 0"
-              class="rounded-full px-1.5 py-0.5 text-xs font-bold"
-              :class="showFilters ? 'bg-rust text-white' : 'bg-rust text-white'"
-            >
-              {{ activeFilterCount }}
-            </span>
-          </button>
-
-          <!-- View Mode Toggle -->
-          <div class="border-navy inline-flex overflow-hidden rounded-lg border-2">
-            <button
-              class="focus-visible:ring-rust px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
-              :class="
-                viewMode === 'list'
-                  ? 'bg-navy text-white'
-                  : 'text-navy hover:bg-paper-deep bg-white'
-              "
-              @click="viewMode = 'list'"
-            >
-              📋 List
-            </button>
-            <button
-              class="border-navy focus-visible:ring-rust border-l-2 px-4 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none"
-              :class="
-                viewMode === 'map'
-                  ? 'bg-navy text-white'
-                  : 'text-navy hover:bg-paper-deep bg-white'
-              "
-              @click="viewMode = 'map'"
-            >
-              🗺️ Map
-            </button>
-          </div>
-        </div>
+      <!-- All spots: the main section with prominent List/Map toggle -->
+      <div
+        class="border-rule mt-10 flex flex-col-reverse items-stretch justify-between gap-3 border-t pt-6 sm:flex-row sm:items-baseline sm:gap-6 sm:pt-7"
+      >
+        <h2
+          class="font-display text-navy m-0 text-xl font-semibold tracking-tight sm:text-2xl"
+        >
+          All spots
+          <span class="font-mono text-muted ml-2 text-xs font-normal">
+            {{ filteredSpaces.length }}<span v-if="filteredSpaces.length !== spaces.length" class="text-faint"> of {{ spaces.length }}</span>
+          </span>
+        </h2>
+        <ViewSegmented v-model="viewMode" />
       </div>
 
-      <!-- Collapsible Filters -->
+      <!-- Toolbar: Open now + filters disclosure -->
+      <div class="mt-4 flex flex-wrap items-center gap-2 sm:gap-3">
+        <OpenNowChip :active="filters.openNow" @toggle="toggleOpenNow" />
+        <button
+          type="button"
+          class="font-sans text-ink hover:text-rust focus-visible:ring-rust inline-flex cursor-pointer items-center gap-1.5 border-0 border-b-2 border-transparent bg-transparent px-1 pb-0.5 text-xs font-medium tracking-[0.04em] uppercase transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          :class="showFilters ? '!border-rust' : ''"
+          :aria-expanded="showFilters"
+          @click="showFilters = !showFilters"
+        >
+          More filters
+          <span
+            v-if="activeFilterCount > 0"
+            class="bg-rust text-paper inline-flex h-4 min-w-4 items-center justify-center px-1 text-[10px] font-bold"
+          >
+            {{ activeFilterCount }}
+          </span>
+        </button>
+      </div>
+
+      <!-- AskBar (smart filter) -->
+      <AskBar @apply="applyAskPatch" />
+
+      <!-- Collapsible filter dropdowns -->
       <FilterBar
         v-show="showFilters"
         :filters="filters"
@@ -209,82 +184,18 @@ function applyAskPatch(patch: Partial<IFilterState>) {
         @update:sort="sort = $event"
       />
 
-      <!-- List View -->
+      <!-- List or Map -->
       <SpaceList v-if="viewMode === 'list'" :spaces="spaces" :filters="filters" :sort="sort" />
-
-      <!-- Map View -->
       <MapView v-else :spaces="filteredSpaces" :all-spaces="spaces" />
+
+      <!-- Marketing callout: Leuven coworking group -->
+      <CoworkingGroupCallout />
+
+      <!-- Footer -->
+      <SiteFooter :total-spaces="spaces.length" />
     </main>
 
-    <!-- Footer -->
-    <footer class="border-rule bg-paper-deep mt-12 border-t-2 px-6 py-8 pb-24">
-      <div class="mx-auto max-w-6xl space-y-6 text-center">
-        <div class="flex flex-col justify-center gap-2 sm:flex-row">
-          <div class="bg-navy w-full rounded-lg p-6 text-white sm:w-auto sm:max-w-md sm:flex-1">
-            <p class="m-0 mb-3 text-lg font-medium">🏢 Know a great coworking spot?</p>
-            <p class="text-faint m-0 mb-4 text-sm">Help fellow remote workers find new places!</p>
-            <div class="flex flex-wrap justify-center gap-3">
-              <a
-                :href="NEW_SPACE_URL"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="bg-rust hover:bg-rust-hover focus-visible:ring-rust rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-              >
-                ✨ Suggest via GitHub
-              </a>
-              <a
-                href="https://pezcuckow.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-navy hover:bg-paper-deep focus-visible:ring-rust rounded bg-white px-4 py-2 text-sm font-semibold no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-              >
-                ✉️ Email me
-              </a>
-            </div>
-          </div>
-          <div
-            class="border-rust w-full rounded-lg border-2 bg-white p-6 sm:w-auto sm:max-w-md sm:flex-1"
-          >
-            <p class="text-navy m-0 mb-2 text-lg font-medium">
-              👋 Looking for people to co-work with?
-            </p>
-            <p class="text-muted m-0 mb-4 text-sm">
-              <strong>Join</strong> the Leuven Social Groups co-working group!
-            </p>
-            <a
-              href="https://labs.pez.io/leuven-social-groups/"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="bg-rust hover:bg-rust-hover focus-visible:ring-rust inline-block rounded px-4 py-2 text-sm font-semibold text-white no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-            >
-              Learn more →
-            </a>
-          </div>
-        </div>
-        <p class="text-muted m-0 text-sm">
-          Made with ☕ in Leuven by
-          <a
-            href="https://pezcuckow.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-muted hover:text-rust focus-visible:ring-rust rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-          >
-            Pez
-          </a>
-          ·
-          <a
-            href="https://github.com/Pezmc/coworking-spaces"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-muted hover:text-rust focus-visible:ring-rust rounded underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-          >
-            Open Source
-          </a>
-        </p>
-      </div>
-    </footer>
-
-    <!-- Visit Progress Bar -->
+    <!-- Visit progress (sticky bottom bar; appears once any space is marked visited) -->
     <VisitProgress :total-spaces="spaces.length" />
   </div>
 </template>

--- a/src/components/AppIcon.vue
+++ b/src/components/AppIcon.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+interface Props {
+  name: string
+  size?: 'sm' | 'md'
+}
+
+withDefaults(defineProps<Props>(), { size: 'md' })
+</script>
+
+<template>
+  <svg
+    class="icon"
+    :class="{ 'icon-sm': size === 'sm' }"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <use :href="'#i-' + name" />
+  </svg>
+</template>
+
+<style>
+.icon {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  vertical-align: -2px;
+  stroke-width: 1.6;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
+}
+.icon-sm {
+  width: 12px;
+  height: 12px;
+  vertical-align: -1.5px;
+}
+</style>

--- a/src/components/AskBar.vue
+++ b/src/components/AskBar.vue
@@ -8,7 +8,6 @@ const emit = defineEmits<{
 }>()
 
 const rawInput = ref('')
-const thinking = ref(false)
 const matches = ref<IAskMatch[]>([])
 
 const EXAMPLES = [
@@ -23,8 +22,14 @@ const placeholderIdx = ref(0)
 const placeholderText = computed(() => EXAMPLES[placeholderIdx.value])
 let placeholderTimer: number | undefined
 
+const reduceMotion =
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
 onMounted(() => {
+  if (reduceMotion) return
   placeholderTimer = window.setInterval(() => {
+    if (rawInput.value) return
     placeholderIdx.value = (placeholderIdx.value + 1) % EXAMPLES.length
   }, 4000)
 })
@@ -54,7 +59,6 @@ function runParse(val: string) {
 watch(rawInput, (val) => {
   if (debounceTimer) clearTimeout(debounceTimer)
   if (!val.trim()) {
-    thinking.value = false
     if (lastAppliedKeys.size > 0) {
       runParse('')
     } else {
@@ -62,12 +66,9 @@ watch(rawInput, (val) => {
     }
     return
   }
-  thinking.value = true
-  const delay = 550 + Math.floor(Math.random() * 300)
   debounceTimer = window.setTimeout(() => {
     runParse(val)
-    thinking.value = false
-  }, delay)
+  }, 250)
 })
 
 function escapeRegex(str: string): string {
@@ -82,10 +83,6 @@ function removeChip(match: IAskMatch) {
     .trim()
 }
 
-function clearAll() {
-  rawInput.value = ''
-}
-
 onBeforeUnmount(() => {
   if (debounceTimer) clearTimeout(debounceTimer)
   if (placeholderTimer) clearInterval(placeholderTimer)
@@ -93,75 +90,39 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="mb-5">
-    <div class="relative">
-      <span
-        class="text-rust pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-base"
-        aria-hidden="true"
-      >
-        ✨
-      </span>
-      <input
-        v-model="rawInput"
-        type="text"
-        :placeholder="placeholderText"
-        class="border-rule text-navy placeholder:text-faint focus-visible:border-rust focus-visible:ring-rust w-full rounded-lg border-2 bg-white py-3 pr-24 pl-11 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-        aria-label="Describe what you need — smart search"
-      />
-      <div
-        v-if="thinking"
-        class="text-muted pointer-events-none absolute top-1/2 right-4 flex -translate-y-1/2 items-center gap-1.5 text-xs"
-        aria-live="polite"
-      >
-        <span>Thinking</span>
-        <span class="flex gap-0.5">
-          <span
-            class="bg-rust inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:0ms] motion-reduce:animate-none"
-          ></span>
-          <span
-            class="bg-rust inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:150ms] motion-reduce:animate-none"
-          ></span>
-          <span
-            class="bg-rust inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:300ms] motion-reduce:animate-none"
-          ></span>
-        </span>
-      </div>
-      <button
-        v-else-if="rawInput"
-        type="button"
-        class="text-muted hover:text-navy focus-visible:ring-rust absolute top-1/2 right-2 -translate-y-1/2 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
-        @click="clearAll"
-      >
-        Clear
-      </button>
-    </div>
+  <div class="ask-bar mt-4 mb-2">
+    <label
+      for="askInput"
+      class="font-mono text-faint mb-1 block text-[10px] tracking-[0.08em] uppercase"
+    >
+      or describe what you want
+    </label>
+    <input
+      id="askInput"
+      v-model="rawInput"
+      type="text"
+      :placeholder="placeholderText"
+      class="font-desc border-rule focus:border-rust w-full border-0 border-b-[1.5px] bg-transparent py-2 pr-2 text-base text-[var(--color-ink)] outline-none transition-colors placeholder:italic placeholder:text-[var(--color-faint)] motion-reduce:transition-none"
+      aria-label="Describe what you're looking for — smart filter"
+    />
 
     <div
       v-if="matches.length > 0"
-      class="mt-2 flex flex-wrap items-center gap-2"
+      class="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2"
       aria-label="Matched filters — click to remove"
     >
-      <span class="text-muted text-xs">Matched:</span>
+      <span class="font-mono text-faint text-[10px] tracking-[0.16em] uppercase">Matched</span>
       <button
         v-for="m in matches"
         :key="m.filter"
         type="button"
-        class="group bg-rust hover:bg-rust-hover focus-visible:ring-navy inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
+        class="font-sans text-ink hover:text-rust focus-visible:ring-rust inline-flex items-baseline gap-1.5 border-0 border-b-2 border-rust bg-transparent px-0 pb-0.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
         :aria-label="`Remove ${m.label} filter`"
         @click="removeChip(m)"
       >
         <span>{{ m.label }}</span>
-        <span
-          aria-hidden="true"
-          class="opacity-70 transition-opacity group-hover:opacity-100 motion-reduce:transition-none"
-        >
-          ×
-        </span>
+        <span aria-hidden="true" class="text-muted text-xs">×</span>
       </button>
     </div>
-
-    <p v-else-if="rawInput && !thinking" class="text-faint mt-2 text-xs" aria-live="polite">
-      Try "quiet", "fast wifi", or "AC"
-    </p>
   </div>
 </template>

--- a/src/components/AskBar.vue
+++ b/src/components/AskBar.vue
@@ -96,7 +96,7 @@ onBeforeUnmount(() => {
   <div class="mb-5">
     <div class="relative">
       <span
-        class="text-accent pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-base"
+        class="text-rust pointer-events-none absolute top-1/2 left-4 -translate-y-1/2 text-base"
         aria-hidden="true"
       >
         ✨
@@ -105,7 +105,7 @@ onBeforeUnmount(() => {
         v-model="rawInput"
         type="text"
         :placeholder="placeholderText"
-        class="border-warm text-primary placeholder:text-faint focus-visible:border-accent focus-visible:ring-accent w-full rounded-lg border-2 bg-white py-3 pr-24 pl-11 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="border-rule text-navy placeholder:text-faint focus-visible:border-rust focus-visible:ring-rust w-full rounded-lg border-2 bg-white py-3 pr-24 pl-11 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         aria-label="Describe what you need — smart search"
       />
       <div
@@ -116,20 +116,20 @@ onBeforeUnmount(() => {
         <span>Thinking</span>
         <span class="flex gap-0.5">
           <span
-            class="bg-accent inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:0ms] motion-reduce:animate-none"
+            class="bg-rust inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:0ms] motion-reduce:animate-none"
           ></span>
           <span
-            class="bg-accent inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:150ms] motion-reduce:animate-none"
+            class="bg-rust inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:150ms] motion-reduce:animate-none"
           ></span>
           <span
-            class="bg-accent inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:300ms] motion-reduce:animate-none"
+            class="bg-rust inline-block h-1 w-1 animate-bounce rounded-full [animation-delay:300ms] motion-reduce:animate-none"
           ></span>
         </span>
       </div>
       <button
         v-else-if="rawInput"
         type="button"
-        class="text-muted hover:text-primary focus-visible:ring-accent absolute top-1/2 right-2 -translate-y-1/2 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
+        class="text-muted hover:text-navy focus-visible:ring-rust absolute top-1/2 right-2 -translate-y-1/2 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
         @click="clearAll"
       >
         Clear
@@ -146,7 +146,7 @@ onBeforeUnmount(() => {
         v-for="m in matches"
         :key="m.filter"
         type="button"
-        class="group bg-accent hover:bg-accent-hover focus-visible:ring-primary inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
+        class="group bg-rust hover:bg-rust-hover focus-visible:ring-navy inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
         :aria-label="`Remove ${m.label} filter`"
         @click="removeChip(m)"
       >

--- a/src/components/CoworkingGroupCallout.vue
+++ b/src/components/CoworkingGroupCallout.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import AppIcon from './AppIcon.vue'
+
+const GROUP_URL = 'https://labs.pez.io/leuven-social-groups/'
+</script>
+
+<template>
+  <aside
+    class="cw-callout border-rust bg-paper-deep relative mt-12 grid grid-cols-1 overflow-hidden border sm:grid-cols-[280px_1fr]"
+    aria-label="Leuven coworking group invitation"
+  >
+    <span
+      class="bg-rust text-paper font-sans absolute top-0 right-0 z-[2] px-2.5 py-1 text-[9.5px] font-medium tracking-[0.18em] uppercase"
+    >
+      A Note
+    </span>
+    <div class="cw-photo h-[140px] sm:h-full sm:min-h-[200px]" role="presentation" />
+    <div class="flex flex-col justify-center gap-2 p-6 sm:px-8 sm:py-7">
+      <span
+        class="text-rust font-sans text-[10px] font-medium tracking-[0.18em] uppercase"
+      >
+        Leuven coworking group
+      </span>
+      <h3
+        class="font-display text-navy m-0 text-2xl font-bold leading-[1.1] tracking-tight sm:text-[28px]"
+      >
+        Working from a café is good. <em class="font-normal italic">Working with people is better.</em>
+      </h3>
+      <p class="font-desc text-ink m-0 max-w-[460px] text-[15px] leading-relaxed">
+        20+ freelancers, devs, and writers in Leuven meet up to co-work around the city. Free to
+        join. No commitment, no Slack noise — just a calendar invite when someone picks a spot.
+      </p>
+      <div class="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2">
+        <a
+          :href="GROUP_URL"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="bg-rust text-paper hover:bg-rust-hover focus-visible:ring-rust border-rust hover:border-rust-hover font-sans inline-flex items-center gap-2 border px-4 py-2.5 text-[13.5px] font-medium tracking-[0.01em] no-underline transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+        >
+          Join the group
+          <AppIcon name="arrow-right" />
+        </a>
+        <span class="font-mono text-muted text-xs tracking-[0.04em]">
+          labs.pez.io/leuven-social-groups
+        </span>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.cw-photo {
+  background:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.25)),
+    radial-gradient(ellipse at 30% 40%, #d4b88a 0%, #8a6a3e 50%, #3a2510 100%);
+  position: relative;
+}
+</style>

--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -64,7 +64,7 @@ function toggle() {
 <template>
   <button
     type="button"
-    class="group focus-visible:ring-rust relative block h-72 w-full cursor-pointer text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none"
+    class="group focus-visible:ring-rust relative block h-32 w-full cursor-pointer text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none sm:h-72"
     :aria-pressed="flipped"
     :aria-label="`${pick.label}: ${pick.space.name} — click to ${flipped ? 'hide' : 'show'} details`"
     @click="toggle"
@@ -73,34 +73,36 @@ function toggle() {
       class="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d] motion-reduce:transition-none"
       :class="flipped ? '[transform:rotateY(180deg)]' : ''"
     >
-      <!-- Front -->
+      <!-- Front: photo-on-left compact on mobile, photo-on-top on sm+ -->
       <div
-        class="border-rule group-hover:border-rust absolute inset-0 flex flex-col overflow-hidden border bg-white transition-colors [backface-visibility:hidden] motion-reduce:transition-none"
+        class="border-rule group-hover:border-rust absolute inset-0 flex flex-row overflow-hidden border bg-white transition-colors [backface-visibility:hidden] motion-reduce:transition-none sm:flex-col"
         :aria-hidden="flipped"
       >
         <div
-          class="h-[120px] w-full flex-shrink-0"
+          class="h-full w-[110px] flex-shrink-0 sm:h-[120px] sm:w-full"
           :style="{ background: photoGradient }"
           role="presentation"
         />
-        <div class="flex flex-1 flex-col gap-2 p-4 sm:p-5">
+        <div class="flex flex-1 flex-col gap-1 p-3 sm:gap-2 sm:p-5">
           <span
-            class="text-rust font-sans text-[10px] font-medium tracking-[0.16em] uppercase"
+            class="text-rust font-sans text-[9.5px] font-medium tracking-[0.14em] uppercase sm:text-[10px] sm:tracking-[0.16em]"
           >
             {{ pick.label }}
           </span>
           <h3
-            class="font-display text-navy m-0 text-xl leading-tight font-semibold tracking-tight sm:text-[22px]"
+            class="font-display text-navy m-0 text-base leading-tight font-semibold tracking-tight sm:text-[22px]"
           >
             {{ pick.space.name }}
           </h3>
-          <p class="font-desc text-muted m-0 text-[12.5px]">{{ pick.hook }}</p>
-          <p class="font-desc text-ink m-0 line-clamp-2 text-[13.5px] leading-relaxed">
+          <p class="font-desc text-muted m-0 hidden text-[12.5px] sm:block">{{ pick.hook }}</p>
+          <p
+            class="font-desc text-ink m-0 hidden line-clamp-2 text-[13.5px] leading-relaxed sm:block"
+          >
             {{ firstSentence }}
           </p>
 
           <div
-            class="border-rule-soft mt-auto flex flex-wrap items-center gap-x-2.5 gap-y-1 border-t pt-2 text-[10px]"
+            class="border-rule-soft mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-1.5 text-[9.5px] sm:gap-x-2.5 sm:border-t sm:pt-2 sm:text-[10px]"
           >
             <template v-for="(pill, i) in pills" :key="pill.label">
               <span
@@ -113,7 +115,7 @@ function toggle() {
             </template>
             <span
               aria-hidden="true"
-              class="font-mono text-faint ml-auto pl-2 text-[9px] tracking-wide"
+              class="font-mono text-faint hidden ml-auto pl-2 text-[9px] tracking-wide sm:inline"
             >
               tap to flip ↻
             </span>

--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -35,7 +35,7 @@ function toggle() {
 <template>
   <button
     type="button"
-    class="group focus-visible:ring-accent relative block h-64 w-full cursor-pointer rounded-lg text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none"
+    class="group focus-visible:ring-rust relative block h-64 w-full cursor-pointer rounded-lg text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none"
     :aria-pressed="flipped"
     :aria-label="`${pick.label}: ${pick.space.name} — click to ${flipped ? 'hide' : 'show'} details`"
     @click="toggle"
@@ -46,14 +46,14 @@ function toggle() {
     >
       <!-- Front -->
       <div
-        class="border-warm group-hover:border-accent absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 bg-white p-5 [backface-visibility:hidden]"
+        class="border-rule group-hover:border-rust absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 bg-white p-5 [backface-visibility:hidden]"
         :aria-hidden="flipped"
       >
         <div>
-          <p class="text-accent m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
+          <p class="text-rust m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
             {{ pick.label }}
           </p>
-          <h3 class="font-display text-primary m-0 mb-1 text-xl font-bold">
+          <h3 class="font-display text-navy m-0 mb-1 text-xl font-bold">
             {{ pick.space.name }}
           </h3>
           <p class="text-muted m-0 text-xs italic">{{ pick.hook }}</p>
@@ -67,7 +67,7 @@ function toggle() {
             <span
               v-for="pill in pills"
               :key="pill"
-              class="bg-cream-panel text-primary rounded-full px-2 py-0.5 text-xs font-medium"
+              class="bg-paper-deep text-navy rounded-full px-2 py-0.5 text-xs font-medium"
             >
               {{ pill }}
             </span>
@@ -81,10 +81,10 @@ function toggle() {
 
       <!-- Back -->
       <div
-        class="border-accent bg-cream absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 p-5 [backface-visibility:hidden]"
+        class="border-rust bg-paper absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 p-5 [backface-visibility:hidden]"
         :aria-hidden="!flipped"
       >
-        <h3 class="font-display text-primary m-0 mb-2 text-lg font-bold">
+        <h3 class="font-display text-navy m-0 mb-2 text-lg font-bold">
           {{ pick.space.name }}
         </h3>
         <p class="text-body m-0 mb-3 text-sm">{{ pick.space.description }}</p>

--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import type { IFeaturedPick } from '../utils/featuredSpaces'
 import { NOISE_LEVEL_LABELS, WIFI_SPEED_LABELS, FOOD_LABELS } from '../types/space'
+import AppIcon from './AppIcon.vue'
 
 interface Props {
   pick: IFeaturedPick
@@ -16,15 +17,43 @@ const firstSentence = computed(() => {
   return (match ? match[0] : d).trim()
 })
 
-const pills = computed(() => {
+interface Pill {
+  icon: string
+  label: string
+}
+
+const pills = computed<Pill[]>(() => {
   const s = props.pick.space
-  const out: string[] = []
-  out.push(NOISE_LEVEL_LABELS[s.noiseLevel])
-  out.push(`${WIFI_SPEED_LABELS[s.wifiSpeed]} WiFi`)
+  const out: Pill[] = []
+  out.push({
+    icon:
+      s.noiseLevel === 'quiet'
+        ? 'volume-quiet'
+        : s.noiseLevel === 'loud'
+          ? 'volume-loud'
+          : 'volume-mid',
+    label: NOISE_LEVEL_LABELS[s.noiseLevel],
+  })
+  out.push({
+    icon: s.wifiSpeed === 'unknown' ? 'wifi-off' : 'wifi',
+    label: `${WIFI_SPEED_LABELS[s.wifiSpeed]} wifi`,
+  })
   if (s.foodAndDrinkAvailability !== 'none') {
-    out.push(FOOD_LABELS[s.foodAndDrinkAvailability])
+    out.push({ icon: 'utensils', label: FOOD_LABELS[s.foodAndDrinkAvailability] })
   }
   return out
+})
+
+const photoGradient = computed(() => {
+  const name = props.pick.space.name
+  let h = 5381
+  for (let i = 0; i < name.length; i++) h = (h * 33) ^ name.charCodeAt(i)
+  const variants = [
+    'radial-gradient(ellipse at 30% 35%, #e9c485 0%, #c39256 35%, #6e4322 80%)',
+    'radial-gradient(ellipse at 60% 30%, #d4b88a 0%, #a07b4a 40%, #5a3a1a 90%)',
+    'radial-gradient(ellipse at 40% 50%, #e0c8a8 0%, #b39060 45%, #6e4f2c 90%)',
+  ]
+  return variants[Math.abs(h) % variants.length]
 })
 
 function toggle() {
@@ -35,7 +64,7 @@ function toggle() {
 <template>
   <button
     type="button"
-    class="group focus-visible:ring-rust relative block h-64 w-full cursor-pointer rounded-lg text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none"
+    class="group focus-visible:ring-rust relative block h-72 w-full cursor-pointer text-left [perspective:1000px] focus-visible:ring-2 focus-visible:outline-none"
     :aria-pressed="flipped"
     :aria-label="`${pick.label}: ${pick.space.name} — click to ${flipped ? 'hide' : 'show'} details`"
     @click="toggle"
@@ -46,60 +75,84 @@ function toggle() {
     >
       <!-- Front -->
       <div
-        class="border-rule group-hover:border-rust absolute inset-0 flex flex-col justify-between overflow-hidden rounded-lg border-2 bg-white p-5 [backface-visibility:hidden]"
+        class="border-rule group-hover:border-rust absolute inset-0 flex flex-col overflow-hidden border bg-white transition-colors [backface-visibility:hidden] motion-reduce:transition-none"
         :aria-hidden="flipped"
       >
-        <div>
-          <p class="text-rust m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
+        <div
+          class="h-[120px] w-full flex-shrink-0"
+          :style="{ background: photoGradient }"
+          role="presentation"
+        />
+        <div class="flex flex-1 flex-col gap-2 p-4 sm:p-5">
+          <span
+            class="text-rust font-sans text-[10px] font-medium tracking-[0.16em] uppercase"
+          >
             {{ pick.label }}
-          </p>
-          <h3 class="font-display text-navy m-0 mb-1 text-xl font-bold">
+          </span>
+          <h3
+            class="font-display text-navy m-0 text-xl leading-tight font-semibold tracking-tight sm:text-[22px]"
+          >
             {{ pick.space.name }}
           </h3>
-          <p class="text-muted m-0 text-xs italic">{{ pick.hook }}</p>
-        </div>
-
-        <div>
-          <p class="text-body m-0 mb-3 line-clamp-3 text-sm">
+          <p class="font-desc text-muted m-0 text-[12.5px]">{{ pick.hook }}</p>
+          <p class="font-desc text-ink m-0 line-clamp-2 text-[13.5px] leading-relaxed">
             {{ firstSentence }}
           </p>
-          <div class="flex flex-wrap gap-1.5">
+
+          <div
+            class="border-rule-soft mt-auto flex flex-wrap items-center gap-x-2.5 gap-y-1 border-t pt-2 text-[10px]"
+          >
+            <template v-for="(pill, i) in pills" :key="pill.label">
+              <span
+                class="text-muted font-sans inline-flex items-center gap-1 font-medium tracking-[0.1em] uppercase"
+              >
+                <AppIcon :name="pill.icon" size="sm" />
+                {{ pill.label }}
+              </span>
+              <span v-if="i < pills.length - 1" class="text-rule">·</span>
+            </template>
             <span
-              v-for="pill in pills"
-              :key="pill"
-              class="bg-paper-deep text-navy rounded-full px-2 py-0.5 text-xs font-medium"
+              aria-hidden="true"
+              class="font-mono text-faint ml-auto pl-2 text-[9px] tracking-wide"
             >
-              {{ pill }}
+              tap to flip ↻
             </span>
           </div>
         </div>
-
-        <span aria-hidden="true" class="text-faint absolute right-3 bottom-3 text-xs">
-          tap to flip ↻
-        </span>
       </div>
 
       <!-- Back -->
       <div
-        class="border-rust bg-paper absolute inset-0 [transform:rotateY(180deg)] overflow-y-auto rounded-lg border-2 p-5 [backface-visibility:hidden]"
+        class="border-rust bg-paper-deep absolute inset-0 overflow-y-auto border p-4 [transform:rotateY(180deg)] [backface-visibility:hidden] sm:p-5"
         :aria-hidden="!flipped"
       >
-        <h3 class="font-display text-navy m-0 mb-2 text-lg font-bold">
+        <h3 class="font-display text-navy m-0 mb-2 text-lg leading-tight font-semibold">
           {{ pick.space.name }}
         </h3>
-        <p class="text-body m-0 mb-3 text-sm">{{ pick.space.description }}</p>
+        <p class="font-desc text-ink m-0 mb-3 text-[14px] leading-relaxed">
+          {{ pick.space.description }}
+        </p>
 
         <div v-if="pick.space.atmosphereNotes" class="mb-2">
-          <p class="text-muted m-0 text-xs font-semibold tracking-wide uppercase">Atmosphere</p>
-          <p class="text-body m-0 text-xs">{{ pick.space.atmosphereNotes }}</p>
+          <p class="text-faint font-sans m-0 text-[10px] font-medium tracking-[0.14em] uppercase">
+            Atmosphere
+          </p>
+          <p class="font-desc text-ink m-0 text-[12.5px]">
+            {{ pick.space.atmosphereNotes }}
+          </p>
         </div>
 
         <div v-if="pick.space.seatingNotes">
-          <p class="text-muted m-0 text-xs font-semibold tracking-wide uppercase">Seating</p>
-          <p class="text-body m-0 text-xs">{{ pick.space.seatingNotes }}</p>
+          <p class="text-faint font-sans m-0 text-[10px] font-medium tracking-[0.14em] uppercase">
+            Seating
+          </p>
+          <p class="font-desc text-ink m-0 text-[12.5px]">{{ pick.space.seatingNotes }}</p>
         </div>
 
-        <span aria-hidden="true" class="text-faint absolute right-3 bottom-3 text-xs">
+        <span
+          aria-hidden="true"
+          class="font-mono text-faint absolute right-3 bottom-3 text-[9px] tracking-wide"
+        >
           tap to flip back ↺
         </span>
       </div>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -79,12 +79,12 @@ const sortOptions: { field: SortField; label: string }[] = [
 </script>
 
 <template>
-  <div class="border-primary bg-cream-panel mb-8 rounded-lg border-2 p-5">
+  <div class="border-navy bg-paper-deep mb-8 rounded-lg border-2 p-5">
     <div class="mb-4 flex flex-wrap items-center justify-between gap-4">
-      <h2 class="font-display text-primary m-0 text-xl font-bold">Filter Spaces</h2>
+      <h2 class="font-display text-navy m-0 text-xl font-bold">Filter Spaces</h2>
       <button
         v-if="hasActiveFilters"
-        class="text-accent hover:text-accent-hover focus-visible:ring-accent cursor-pointer rounded border-0 bg-transparent text-sm underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="text-rust hover:text-rust-hover focus-visible:ring-rust cursor-pointer rounded border-0 bg-transparent text-sm underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         @click="resetFilters"
       >
         Clear all filters
@@ -97,7 +97,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Noise </label>
         <select
           :value="filters.noiseLevel"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'noiseLevel',
@@ -117,7 +117,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> WiFi </label>
         <select
           :value="filters.wifiSpeed"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'wifiSpeed',
@@ -137,7 +137,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Climate </label>
         <select
           :value="filters.hasAC"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'hasAC',
@@ -157,7 +157,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Food </label>
         <select
           :value="filters.foodAvailability"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'foodAvailability',
@@ -177,7 +177,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Seating </label>
         <select
           :value="filters.seatingType"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'seatingType',
@@ -197,7 +197,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Outlets </label>
         <select
           :value="filters.hasOutlets"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'hasOutlets',
@@ -217,7 +217,7 @@ const sortOptions: { field: SortField; label: string }[] = [
         <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Status </label>
         <select
           :value="filters.verified"
-          class="border-cool text-ink hover:border-accent focus-visible:ring-accent cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           @change="
             updateFilter(
               'verified',
@@ -233,17 +233,17 @@ const sortOptions: { field: SortField; label: string }[] = [
     </div>
 
     <!-- Sort -->
-    <div class="border-cool flex items-center gap-3 border-t pt-4">
+    <div class="border-rule flex items-center gap-3 border-t pt-4">
       <span class="text-muted text-xs font-semibold tracking-wide uppercase"> Sort by: </span>
       <div class="flex gap-2">
         <button
           v-for="option in sortOptions"
           :key="option.field"
-          class="focus-visible:ring-accent cursor-pointer rounded border-2 px-3 py-1.5 text-sm transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="focus-visible:ring-rust cursor-pointer rounded border-2 px-3 py-1.5 text-sm transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           :class="
             sort.field === option.field
-              ? 'border-primary bg-primary text-white'
-              : 'border-cool text-primary hover:border-primary bg-white'
+              ? 'border-navy bg-navy text-white'
+              : 'border-rule text-navy hover:border-navy bg-white'
           "
           @click="updateSort(option.field)"
         >

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -21,9 +21,9 @@ import {
 } from '../types/space'
 
 const VERIFIED_LABELS: Record<VerifiedFilter, string> = {
-  all: 'All Spaces',
-  verified: 'Verified Only',
-  unverified: 'Unverified Only',
+  all: 'All spaces',
+  verified: 'Verified only',
+  unverified: 'Unverified only',
 }
 
 interface Props {
@@ -73,31 +73,32 @@ const hasActiveFilters = computed(() => {
 
 const sortOptions: { field: SortField; label: string }[] = [
   { field: 'name', label: 'Name' },
-  { field: 'wifiSpeed', label: 'WiFi Speed' },
-  { field: 'noiseLevel', label: 'Noise Level' },
+  { field: 'wifiSpeed', label: 'Wifi' },
+  { field: 'noiseLevel', label: 'Noise' },
 ]
 </script>
 
 <template>
-  <div class="border-navy bg-paper-deep mb-8 rounded-lg border-2 p-5">
-    <div class="mb-4 flex flex-wrap items-center justify-between gap-4">
-      <h2 class="font-display text-navy m-0 text-xl font-bold">Filter Spaces</h2>
+  <div class="border-rule mt-3 mb-6 border-t border-b py-5">
+    <div class="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+      <h3 class="font-mono text-faint m-0 text-[10px] tracking-[0.16em] uppercase">
+        More filters
+      </h3>
       <button
         v-if="hasActiveFilters"
-        class="text-rust hover:text-rust-hover focus-visible:ring-rust cursor-pointer rounded border-0 bg-transparent text-sm underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="text-ink hover:text-rust focus-visible:ring-rust font-sans cursor-pointer border-0 border-b border-rust bg-transparent p-0 pb-px text-xs focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         @click="resetFilters"
       >
-        Clear all filters
+        Clear filters
       </button>
     </div>
 
-    <div class="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4 lg:grid-cols-7">
-      <!-- Noise Level -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Noise </label>
+    <div class="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Noise</span>
         <select
           :value="filters.noiseLevel"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'noiseLevel',
@@ -110,14 +111,13 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ NOISE_LEVEL_LABELS[level] }}
           </option>
         </select>
-      </div>
+      </label>
 
-      <!-- WiFi Speed -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> WiFi </label>
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Wifi</span>
         <select
           :value="filters.wifiSpeed"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'wifiSpeed',
@@ -130,14 +130,13 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ WIFI_SPEED_LABELS[speed] }}
           </option>
         </select>
-      </div>
+      </label>
 
-      <!-- AC -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Climate </label>
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Climate</span>
         <select
           :value="filters.hasAC"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'hasAC',
@@ -150,14 +149,13 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ AC_LABELS[opt] }}
           </option>
         </select>
-      </div>
+      </label>
 
-      <!-- Food -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Food </label>
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Food</span>
         <select
           :value="filters.foodAvailability"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'foodAvailability',
@@ -170,14 +168,13 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ FOOD_LABELS[opt] }}
           </option>
         </select>
-      </div>
+      </label>
 
-      <!-- Seating -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Seating </label>
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Seating</span>
         <select
           :value="filters.seatingType"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'seatingType',
@@ -190,14 +187,13 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ SEATING_LABELS[opt] }}
           </option>
         </select>
-      </div>
+      </label>
 
-      <!-- Outlets -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Outlets </label>
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Outlets</span>
         <select
           :value="filters.hasOutlets"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'hasOutlets',
@@ -210,14 +206,13 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ OUTLET_LABELS[opt] }}
           </option>
         </select>
-      </div>
+      </label>
 
-      <!-- Verified -->
-      <div class="flex flex-col gap-1">
-        <label class="text-muted text-xs font-semibold tracking-wide uppercase"> Status </label>
+      <label class="flex flex-col gap-1">
+        <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Status</span>
         <select
           :value="filters.verified"
-          class="border-rule text-ink hover:border-rust focus-visible:ring-rust cursor-pointer rounded border-2 bg-white px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="filter-select"
           @change="
             updateFilter(
               'verified',
@@ -229,26 +224,23 @@ const sortOptions: { field: SortField; label: string }[] = [
             {{ VERIFIED_LABELS[opt] }}
           </option>
         </select>
-      </div>
+      </label>
     </div>
 
-    <!-- Sort -->
-    <div class="border-rule flex items-center gap-3 border-t pt-4">
-      <span class="text-muted text-xs font-semibold tracking-wide uppercase"> Sort by: </span>
-      <div class="flex gap-2">
+    <div
+      class="border-rule-soft mt-4 flex flex-wrap items-baseline gap-x-4 gap-y-2 border-t pt-4"
+    >
+      <span class="font-sans text-faint text-[10px] tracking-[0.12em] uppercase">Sort by</span>
+      <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
         <button
           v-for="option in sortOptions"
           :key="option.field"
-          class="focus-visible:ring-rust cursor-pointer rounded border-2 px-3 py-1.5 text-sm transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-          :class="
-            sort.field === option.field
-              ? 'border-navy bg-navy text-white'
-              : 'border-rule text-navy hover:border-navy bg-white'
-          "
+          class="font-sans text-muted hover:text-ink focus-visible:ring-rust cursor-pointer border-0 border-b-2 border-transparent bg-transparent px-0.5 pb-0.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          :class="sort.field === option.field ? 'text-ink !border-rust' : ''"
           @click="updateSort(option.field)"
         >
           {{ option.label }}
-          <span v-if="sort.field === option.field" class="ml-1">
+          <span v-if="sort.field === option.field" aria-hidden="true" class="ml-0.5 text-xs">
             {{ sort.direction === 'asc' ? '↑' : '↓' }}
           </span>
         </button>
@@ -256,3 +248,30 @@ const sortOptions: { field: SortField; label: string }[] = [
     </div>
   </div>
 </template>
+
+<style scoped>
+.filter-select {
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-size: 13px;
+  color: var(--color-ink);
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--color-rule);
+  padding: 4px 0;
+  cursor: pointer;
+  transition: border-color 120ms;
+}
+.filter-select:hover {
+  border-bottom-color: var(--color-rust);
+}
+.filter-select:focus-visible {
+  outline: none;
+  border-bottom-color: var(--color-rust);
+  box-shadow: 0 1px 0 0 var(--color-rust);
+}
+@media (prefers-reduced-motion: reduce) {
+  .filter-select {
+    transition: none;
+  }
+}
+</style>

--- a/src/components/IconDefs.vue
+++ b/src/components/IconDefs.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+// Hidden SVG symbol library. Mounted once at the top of App.vue.
+// Icons are referenced via <AppIcon name="…" /> which emits <use href="#i-name" />.
+// Inventory and rules in DESIGN.md > Component conventions > Iconography.
+</script>
+
+<template>
+  <svg width="0" height="0" style="position: absolute" aria-hidden="true">
+    <defs>
+      <symbol id="i-volume-quiet" viewBox="0 0 24 24">
+        <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+      </symbol>
+      <symbol id="i-volume-mid" viewBox="0 0 24 24">
+        <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+        <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+      </symbol>
+      <symbol id="i-volume-loud" viewBox="0 0 24 24">
+        <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+        <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+        <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+      </symbol>
+      <symbol id="i-wifi" viewBox="0 0 24 24">
+        <path d="M5 13a10 10 0 0 1 14 0" />
+        <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+        <path d="M2 8.82a15 15 0 0 1 20 0" />
+        <line x1="12" x2="12.01" y1="20" y2="20" />
+      </symbol>
+      <symbol id="i-wifi-off" viewBox="0 0 24 24">
+        <path d="M12 20h.01" />
+        <path d="M8.5 16.429a5 5 0 0 1 7 0" />
+        <path d="M5 12.859a10 10 0 0 1 5.17-2.69" />
+        <path d="M19 12.859a10 10 0 0 0-2.007-1.523" />
+        <path d="M2 8.82a15 15 0 0 1 4.177-2.643" />
+        <path d="M22 8.82a15 15 0 0 0-11.288-3.764" />
+        <path d="m2 2 20 20" />
+      </symbol>
+      <symbol id="i-plug" viewBox="0 0 24 24">
+        <path d="M12 22v-5" />
+        <path d="M9 7V2" />
+        <path d="M15 7V2" />
+        <path d="M6 13V8h12v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4Z" />
+      </symbol>
+      <symbol id="i-snowflake" viewBox="0 0 24 24">
+        <line x1="2" x2="22" y1="12" y2="12" />
+        <line x1="12" x2="12" y1="2" y2="22" />
+        <path d="m20 16-4-4 4-4" />
+        <path d="m4 8 4 4-4 4" />
+        <path d="m16 4-4 4-4-4" />
+        <path d="m8 20 4-4 4 4" />
+      </symbol>
+      <symbol id="i-utensils" viewBox="0 0 24 24">
+        <path d="M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2" />
+        <path d="M7 2v20" />
+        <path d="M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7" />
+      </symbol>
+      <symbol id="i-armchair" viewBox="0 0 24 24">
+        <path d="M19 9V6a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v3" />
+        <path
+          d="M3 11v5a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5a2 2 0 0 0-4 0v2H7v-2a2 2 0 0 0-4 0Z"
+        />
+        <path d="M5 18v2" />
+        <path d="M19 18v2" />
+      </symbol>
+      <symbol id="i-sun" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2" />
+        <path d="M12 20v2" />
+        <path d="m4.93 4.93 1.41 1.41" />
+        <path d="m17.66 17.66 1.41 1.41" />
+        <path d="M2 12h2" />
+        <path d="M20 12h2" />
+        <path d="m6.34 17.66-1.41 1.41" />
+        <path d="m19.07 4.93-1.41 1.41" />
+      </symbol>
+      <symbol id="i-moon" viewBox="0 0 24 24">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+      </symbol>
+      <symbol id="i-map-pin" viewBox="0 0 24 24">
+        <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+        <circle cx="12" cy="10" r="3" />
+      </symbol>
+      <symbol id="i-check" viewBox="0 0 24 24">
+        <path d="M20 6 9 17l-5-5" />
+      </symbol>
+      <symbol id="i-clock" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </symbol>
+      <symbol id="i-list" viewBox="0 0 24 24">
+        <line x1="8" x2="21" y1="6" y2="6" />
+        <line x1="8" x2="21" y1="12" y2="12" />
+        <line x1="8" x2="21" y1="18" y2="18" />
+        <line x1="3" x2="3.01" y1="6" y2="6" />
+        <line x1="3" x2="3.01" y1="12" y2="12" />
+        <line x1="3" x2="3.01" y1="18" y2="18" />
+      </symbol>
+      <symbol id="i-arrow-right" viewBox="0 0 24 24">
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </symbol>
+      <symbol id="i-x" viewBox="0 0 24 24">
+        <path d="M18 6 6 18" />
+        <path d="m6 6 12 12" />
+      </symbol>
+    </defs>
+  </svg>
+</template>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -92,7 +92,7 @@ function getMarkerIcon(space: ICoworkingSpace) {
 </script>
 
 <template>
-  <div class="map-container border-warm overflow-hidden rounded-lg border-2" style="height: 600px">
+  <div class="map-container border-rule overflow-hidden rounded-lg border-2" style="height: 600px">
     <LMap
       ref="mapRef"
       :zoom="zoom"
@@ -124,7 +124,7 @@ function getMarkerIcon(space: ICoworkingSpace) {
     <!-- No results message -->
     <div
       v-if="spaces.filter((s) => s.coordinates).length === 0"
-      class="bg-cream-panel/90 absolute inset-0 flex items-center justify-center"
+      class="bg-paper-deep/90 absolute inset-0 flex items-center justify-center"
     >
       <p class="text-muted text-lg">No spaces match your filters</p>
     </div>

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -1,15 +1,34 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import type L from 'leaflet'
+import L from 'leaflet'
 import { LMap, LTileLayer, LMarker, LPopup } from '@vue-leaflet/vue-leaflet'
 import 'leaflet/dist/leaflet.css'
 import { type ICoworkingSpace } from '../types/space'
 import { slugify } from '../utils/slug'
 import SpaceSummary from './SpaceSummary.vue'
 
+// Build the custom rust pin icons synchronously so they're available
+// on first marker render. divIcon HTML is styled via the global CSS
+// in this component's <style> block.
+const verifiedIcon = L.divIcon({
+  className: 'cw-pin cw-pin--verified',
+  html: '<span class="cw-pin-dot" aria-hidden="true"></span>',
+  iconSize: [22, 22],
+  iconAnchor: [11, 11],
+  popupAnchor: [0, -12],
+})
+
+const unverifiedIcon = L.divIcon({
+  className: 'cw-pin cw-pin--unverified',
+  html: '<span class="cw-pin-dot" aria-hidden="true"></span>',
+  iconSize: [20, 20],
+  iconAnchor: [10, 10],
+  popupAnchor: [0, -10],
+})
+
 interface Props {
-  spaces: ICoworkingSpace[] // Filtered spaces to show as markers
-  allSpaces: ICoworkingSpace[] // All spaces for calculating bounds
+  spaces: ICoworkingSpace[]
+  allSpaces: ICoworkingSpace[]
 }
 
 const props = defineProps<Props>()
@@ -17,11 +36,10 @@ const props = defineProps<Props>()
 const mapRef = ref<InstanceType<typeof LMap> | null>(null)
 const hasFittedBounds = ref(false)
 
-// Use ALL spaces for center calculation so filtering doesn't shift the map
 const mapCenter = computed(() => {
   const validSpaces = props.allSpaces.filter((s) => s.coordinates)
   if (validSpaces.length === 0) {
-    return [50.8798, 4.7005] as [number, number] // Leuven center
+    return [50.8798, 4.7005] as [number, number]
   }
 
   const avgLat = validSpaces.reduce((sum, s) => sum + s.coordinates!.lat, 0) / validSpaces.length
@@ -31,9 +49,7 @@ const mapCenter = computed(() => {
 
 const zoom = ref(14)
 
-// Fit bounds once on mount to prevent jarring map movements when filters change
 onMounted(() => {
-  // Small delay to ensure map is ready
   setTimeout(() => {
     if (mapRef.value && !hasFittedBounds.value) {
       const validSpaces = props.allSpaces.filter((s) => s.coordinates)
@@ -44,55 +60,22 @@ onMounted(() => {
         const map = mapRef.value as unknown as {
           leafletObject?: { fitBounds: (b: Array<[number, number]>, o: object) => void }
         }
-        map.leafletObject?.fitBounds(bounds, { padding: [50, 50] })
+        map.leafletObject?.fitBounds(bounds, { padding: [40, 40] })
         hasFittedBounds.value = true
       }
     }
   }, 100)
 })
 
-const verifiedIcon = ref<L.Icon | null>(null)
-const unverifiedIcon = ref<L.Icon | null>(null)
-
-// Leaflet's default icon paths break with bundlers - manually set CDN URLs
-onMounted(async () => {
-  const L = await import('leaflet')
-  delete (L.Icon.Default.prototype as any)._getIconUrl
-  L.Icon.Default.mergeOptions({
-    iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-  })
-
-  verifiedIcon.value = new L.Icon({
-    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-    iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-    shadowSize: [41, 41],
-  })
-
-  unverifiedIcon.value = new L.Icon({
-    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-    iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-    shadowSize: [41, 41],
-    className: 'unverified-marker',
-  })
-})
-
 function getMarkerIcon(space: ICoworkingSpace) {
-  return space.verified ? verifiedIcon.value : unverifiedIcon.value
+  return space.verified ? verifiedIcon : unverifiedIcon
 }
 </script>
 
 <template>
-  <div class="map-container border-rule overflow-hidden rounded-lg border-2" style="height: 600px">
+  <div
+    class="border-rule relative mt-3 h-[60vh] min-h-[500px] overflow-hidden border sm:h-[600px]"
+  >
     <LMap
       ref="mapRef"
       :zoom="zoom"
@@ -101,19 +84,19 @@ function getMarkerIcon(space: ICoworkingSpace) {
       style="height: 100%; width: 100%"
     >
       <LTileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors'
+        url="https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png"
+        attribution='&copy; <a href="https://stadiamaps.com/" target="_blank" rel="noopener noreferrer">Stadia Maps</a> &copy; <a href="https://stamen.com/" target="_blank" rel="noopener noreferrer">Stamen Design</a> &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors'
         layer-type="base"
-        name="OpenStreetMap"
+        name="Stamen Toner Lite"
       />
 
       <LMarker
         v-for="space in spaces.filter((s) => s.coordinates)"
         :key="slugify(space.name)"
         :lat-lng="[space.coordinates!.lat, space.coordinates!.lng]"
-        :options="getMarkerIcon(space) ? { icon: getMarkerIcon(space) } : {}"
+        :options="{ icon: getMarkerIcon(space) }"
       >
-        <LPopup :options="{ maxWidth: 300, minWidth: 250 }">
+        <LPopup :options="{ maxWidth: 280, minWidth: 240, closeButton: true }">
           <div class="space-popup">
             <SpaceSummary :space="space" compact />
           </div>
@@ -121,46 +104,87 @@ function getMarkerIcon(space: ICoworkingSpace) {
       </LMarker>
     </LMap>
 
-    <!-- No results message -->
+    <!-- Centrum stamp top-left -->
+    <div
+      class="bg-paper/90 border-rule font-mono text-muted absolute top-3 left-3 z-[400] border px-2 py-1 text-[10px] tracking-[0.06em] uppercase"
+      aria-hidden="true"
+    >
+      Leuven
+    </div>
+
     <div
       v-if="spaces.filter((s) => s.coordinates).length === 0"
-      class="bg-paper-deep/90 absolute inset-0 flex items-center justify-center"
+      class="bg-paper/90 absolute inset-0 z-[500] flex items-center justify-center"
     >
-      <p class="text-muted text-lg">No spaces match your filters</p>
+      <p class="font-display text-navy text-xl italic">No spaces match.</p>
     </div>
   </div>
 </template>
 
-<style scoped>
-.map-container {
-  position: relative;
+<style>
+/* Custom Lucide-shaped Leaflet markers — global so they can target divIcon descendants */
+.cw-pin {
+  background: var(--color-rust);
+  border: 2px solid var(--color-paper);
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 120ms;
+}
+.cw-pin:hover {
+  transform: scale(1.15);
+}
+.cw-pin--unverified {
+  background: var(--color-paper);
+  border-color: var(--color-rust);
+  opacity: 0.85;
+}
+.cw-pin-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--color-paper);
+  border-radius: 50%;
+}
+.cw-pin--unverified .cw-pin-dot {
+  background: var(--color-rust);
+  width: 5px;
+  height: 5px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cw-pin {
+    transition: none;
+  }
 }
 
-/* Override Leaflet popup styles */
-:deep(.leaflet-popup-content-wrapper) {
-  border-radius: 8px;
-  box-shadow:
-    0 4px 6px -1px rgb(0 0 0 / 0.1),
-    0 2px 4px -2px rgb(0 0 0 / 0.1);
+/* Popup chrome */
+.leaflet-popup-content-wrapper {
+  background: var(--color-paper);
+  color: var(--color-ink);
+  border: 1px solid var(--color-navy);
+  border-radius: 0 !important;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12) !important;
 }
-
-:deep(.leaflet-popup-content) {
-  margin: 12px 14px;
-}
-
-:deep(.leaflet-popup-close-button) {
-  color: #718096;
-  font-size: 20px;
-  padding: 8px;
-}
-
-.space-popup {
+.leaflet-popup-content {
+  margin: 14px 16px !important;
   font-family: inherit;
 }
-
-/* Unverified marker styling - more transparent/faded */
-:deep(.unverified-marker) {
-  opacity: 0.5;
-  filter: grayscale(50%);
+.leaflet-popup-tip {
+  background: var(--color-paper);
+  border: 1px solid var(--color-navy);
+}
+.leaflet-popup-close-button {
+  color: var(--color-muted) !important;
+  font-size: 18px !important;
+  padding: 6px 8px !important;
+}
+.leaflet-popup-close-button:hover {
+  color: var(--color-rust) !important;
+}
+.space-popup {
+  font-family: inherit;
 }
 </style>

--- a/src/components/OpenNowChip.vue
+++ b/src/components/OpenNowChip.vue
@@ -41,10 +41,10 @@ const title = computed(() =>
     :title="title"
     :class="[
       'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors motion-reduce:transition-none',
-      'focus-visible:ring-accent focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+      'focus-visible:ring-rust focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
       active
-        ? 'border-primary bg-primary hover:bg-primary-hover text-white'
-        : 'border-primary text-primary hover:bg-cream-panel bg-white',
+        ? 'border-navy bg-navy hover:bg-navy-hover text-white'
+        : 'border-navy text-navy hover:bg-paper-deep bg-white',
       loading && 'cursor-wait opacity-70',
     ]"
     @click="emit('toggle')"

--- a/src/components/OpenNowChip.vue
+++ b/src/components/OpenNowChip.vue
@@ -40,11 +40,11 @@ const title = computed(() =>
     :aria-label="ariaLabel"
     :title="title"
     :class="[
-      'inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded-lg border-2 px-3 py-2 text-sm font-medium transition-colors motion-reduce:transition-none',
+      'font-sans inline-flex min-h-[40px] cursor-pointer items-center gap-1.5 border px-3.5 py-2 text-xs font-medium tracking-[0.04em] uppercase transition-colors motion-reduce:transition-none',
       'focus-visible:ring-rust focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
       active
-        ? 'border-navy bg-navy hover:bg-navy-hover text-white'
-        : 'border-navy text-navy hover:bg-paper-deep bg-white',
+        ? 'border-navy bg-navy text-paper hover:bg-navy-hover'
+        : 'border-navy text-ink hover:bg-paper-deep bg-white',
       loading && 'cursor-wait opacity-70',
     ]"
     @click="emit('toggle')"

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { NEW_SPACE_URL } from '../utils/issueUrl'
+
+interface Props {
+  totalSpaces: number
+}
+
+defineProps<Props>()
+
+const REPO_URL = 'https://github.com/Pezmc/coworking-spaces'
+
+// Last-updated stamp uses build time for now; could be wired to git later.
+const lastUpdated = new Date().toLocaleDateString('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+})
+</script>
+
+<template>
+  <footer
+    class="border-rule mt-14 flex flex-col items-baseline justify-between gap-2 border-t pt-7 pb-32 sm:flex-row sm:gap-6 sm:pb-24"
+  >
+    <p class="font-sans text-muted m-0 text-sm leading-relaxed">
+      Know a good spot that's missing?
+      <a
+        :href="NEW_SPACE_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-ink hover:text-rust focus-visible:ring-rust border-rust border-b pb-px focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        Suggest a café
+      </a>
+      ·
+      <a
+        :href="REPO_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-ink hover:text-rust focus-visible:ring-rust border-rust border-b pb-px focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        Open source on GitHub
+      </a>
+    </p>
+    <span class="font-mono text-faint text-[11px] tracking-[0.04em]">
+      {{ totalSpaces }} cafés · last updated {{ lastUpdated.toLowerCase() }}
+    </span>
+  </footer>
+</template>

--- a/src/components/SpaceCard.vue
+++ b/src/components/SpaceCard.vue
@@ -13,103 +13,127 @@ const props = defineProps<Props>()
 
 const expanded = ref(false)
 const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
+
+// Deterministic gradient placeholder until imageUrl exists.
+const photoGradient = computed(() => {
+  const name = props.space.name
+  let h = 5381
+  for (let i = 0; i < name.length; i++) h = (h * 33) ^ name.charCodeAt(i)
+  const variants = [
+    'linear-gradient(135deg, #d4b88a, #8a6a3e)',
+    'linear-gradient(135deg, #b8a99a, #5a4530)',
+    'linear-gradient(135deg, #c8c1b0, #6e6855)',
+    'linear-gradient(135deg, #d8b9a0, #7a4a2e)',
+  ]
+  return variants[Math.abs(h) % variants.length]
+})
 </script>
 
 <template>
   <article
-    class="border-rule hover:border-rust overflow-hidden rounded-lg border-2 bg-white transition-all duration-200 hover:shadow-lg motion-reduce:transition-none"
+    class="entry border-rule-soft hover:bg-rust/[0.03] grid grid-cols-[64px_1fr] gap-3 border-b py-5 transition-colors motion-reduce:transition-none sm:grid-cols-[88px_1fr] sm:gap-5"
     :class="{ 'opacity-70': !space.verified }"
   >
-    <!-- Header with Summary -->
-    <div class="border-rule border-b p-5">
+    <div
+      class="entry-photo h-[64px] w-[64px] flex-shrink-0 sm:h-[88px] sm:w-[88px]"
+      :style="{ background: photoGradient }"
+      role="presentation"
+    />
+
+    <div class="min-w-0">
       <SpaceSummary :space="space">
         <template #title>
           <span :id="slugify(space.name)">{{ space.name }}</span>
         </template>
       </SpaceSummary>
-    </div>
 
-    <!-- Expandable Details -->
-    <div class="px-5 py-3">
       <button
-        class="text-navy focus-visible:ring-rust flex w-full cursor-pointer items-center justify-between rounded border-0 bg-transparent py-1 text-sm font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        type="button"
+        class="text-muted hover:text-rust focus-visible:ring-rust font-sans mt-3 inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 text-xs font-medium tracking-wide uppercase transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+        :aria-expanded="expanded"
         @click="expanded = !expanded"
       >
-        <span>{{ expanded ? 'Hide details' : 'Show details' }}</span>
+        <span>{{ expanded ? 'Hide details' : 'More' }}</span>
         <span
-          class="transform transition-transform motion-reduce:transition-none"
+          aria-hidden="true"
+          class="inline-block transition-transform motion-reduce:transition-none"
           :class="{ 'rotate-180': expanded }"
         >
-          ▼
+          ▾
         </span>
       </button>
 
-      <div v-show="expanded" class="mt-4 space-y-3 text-sm">
-        <!-- Atmosphere -->
+      <div v-show="expanded" class="font-desc mt-3 space-y-3 text-[14px] leading-relaxed">
         <div v-if="space.atmosphereNotes">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
             Atmosphere
           </h4>
-          <p class="text-body m-0">{{ space.atmosphereNotes }}</p>
+          <p class="text-ink m-0">{{ space.atmosphereNotes }}</p>
         </div>
 
-        <!-- Seating -->
         <div v-if="space.seatingNotes">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Seating</h4>
-          <p class="text-body m-0">{{ space.seatingNotes }}</p>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            Seating
+          </h4>
+          <p class="text-ink m-0">{{ space.seatingNotes }}</p>
         </div>
 
-        <!-- WiFi Notes -->
         <div v-if="space.wifiNotes">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">WiFi</h4>
-          <p class="text-body m-0">{{ space.wifiNotes }}</p>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            WiFi
+          </h4>
+          <p class="text-ink m-0">{{ space.wifiNotes }}</p>
         </div>
 
-        <!-- Climate -->
         <div v-if="space.climateNotes">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Climate</h4>
-          <p class="text-body m-0">{{ space.climateNotes }}</p>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            Climate
+          </h4>
+          <p class="text-ink m-0">{{ space.climateNotes }}</p>
         </div>
 
-        <!-- Outlets -->
         <div>
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Outlets</h4>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            Outlets
+          </h4>
           <p
             v-tippy="OUTLET_DESCRIPTIONS[space.hasOutlets]"
-            class="text-body m-0 inline-block cursor-help"
+            class="text-ink m-0 inline-block cursor-help"
           >
             {{ OUTLET_LABELS[space.hasOutlets] }}
           </p>
-          <p v-if="space.outletNotes" class="text-body m-0 mt-1 text-xs">
+          <p v-if="space.outletNotes" class="text-ink m-0 mt-1 text-xs">
             {{ space.outletNotes }}
           </p>
         </div>
 
-        <!-- Drinks -->
         <div v-if="space.drinkNotes">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Drinks</h4>
-          <p class="text-body m-0">{{ space.drinkNotes }}</p>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            Drinks
+          </h4>
+          <p class="text-ink m-0">{{ space.drinkNotes }}</p>
         </div>
 
-        <!-- Food -->
         <div v-if="space.foodNotes">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Food</h4>
-          <p class="text-body m-0">{{ space.foodNotes }}</p>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            Food
+          </h4>
+          <p class="text-ink m-0">{{ space.foodNotes }}</p>
         </div>
 
-        <!-- Opening Hours -->
         <div v-if="space.openingHours">
-          <h4 class="text-muted m-0 mb-1 text-xs font-semibold tracking-wide uppercase">Hours</h4>
-          <p class="text-body m-0">{{ space.openingHours }}</p>
+          <h4 class="text-faint font-sans m-0 mb-0.5 text-[10px] font-medium tracking-[0.14em] uppercase not-italic">
+            Hours
+          </h4>
+          <p class="font-mono text-ink m-0 text-xs not-italic">{{ space.openingHours }}</p>
         </div>
 
-        <!-- Update link for verified spaces -->
-        <div v-if="space.verified" class="border-rule mt-3 border-t pt-3">
+        <div v-if="space.verified" class="border-rule-soft mt-3 border-t pt-3">
           <a
             :href="updateUrl"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-muted hover:text-rust focus-visible:ring-rust rounded text-xs hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            class="text-muted hover:text-rust focus-visible:ring-rust font-sans rounded text-xs not-italic hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Something wrong? Update this space →
           </a>

--- a/src/components/SpaceCard.vue
+++ b/src/components/SpaceCard.vue
@@ -17,11 +17,11 @@ const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
 
 <template>
   <article
-    class="border-warm hover:border-accent overflow-hidden rounded-lg border-2 bg-white transition-all duration-200 hover:shadow-lg motion-reduce:transition-none"
+    class="border-rule hover:border-rust overflow-hidden rounded-lg border-2 bg-white transition-all duration-200 hover:shadow-lg motion-reduce:transition-none"
     :class="{ 'opacity-70': !space.verified }"
   >
     <!-- Header with Summary -->
-    <div class="border-warm border-b p-5">
+    <div class="border-rule border-b p-5">
       <SpaceSummary :space="space">
         <template #title>
           <span :id="slugify(space.name)">{{ space.name }}</span>
@@ -32,7 +32,7 @@ const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
     <!-- Expandable Details -->
     <div class="px-5 py-3">
       <button
-        class="text-primary focus-visible:ring-accent flex w-full cursor-pointer items-center justify-between rounded border-0 bg-transparent py-1 text-sm font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="text-navy focus-visible:ring-rust flex w-full cursor-pointer items-center justify-between rounded border-0 bg-transparent py-1 text-sm font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         @click="expanded = !expanded"
       >
         <span>{{ expanded ? 'Hide details' : 'Show details' }}</span>
@@ -104,12 +104,12 @@ const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
         </div>
 
         <!-- Update link for verified spaces -->
-        <div v-if="space.verified" class="border-warm mt-3 border-t pt-3">
+        <div v-if="space.verified" class="border-rule mt-3 border-t pt-3">
           <a
             :href="updateUrl"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-muted hover:text-accent focus-visible:ring-accent rounded text-xs hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            class="text-muted hover:text-rust focus-visible:ring-rust rounded text-xs hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Something wrong? Update this space →
           </a>

--- a/src/components/SpaceList.vue
+++ b/src/components/SpaceList.vue
@@ -88,29 +88,28 @@ const filteredAndSortedSpaces = computed(() => {
     <!-- Empty state -->
     <div
       v-if="filteredAndSortedSpaces.length === 0"
-      class="border-rule bg-paper-deep rounded-lg border-2 border-dashed px-6 py-12 text-center"
+      class="border-rule border-y px-2 py-10 text-center"
     >
       <template v-if="isOnlyOpenNowActive">
-        <p class="text-muted m-0 mb-2 text-lg">Nothing open right now</p>
-        <p class="text-faint m-0 text-sm">
-          Leuven is quiet at this hour. Try turning off <strong>Open now</strong>, or check back
-          later.
+        <p class="font-display text-navy m-0 mb-2 text-xl italic">Nothing's open right now.</p>
+        <p class="text-muted font-sans m-0 text-sm">
+          Leuven keeps odd café hours. Try again after lunch, or clear the filter.
         </p>
       </template>
       <template v-else-if="props.filters.openNow">
-        <p class="text-muted m-0 mb-2 text-lg">No open spaces match your filters</p>
-        <p class="text-faint m-0 text-sm">
-          Try removing <strong>Open now</strong> or loosening another filter.
+        <p class="font-display text-navy m-0 mb-2 text-xl italic">No open spots match.</p>
+        <p class="text-muted font-sans m-0 text-sm">
+          Try clearing <strong class="font-medium">Open now</strong> or loosening another filter.
         </p>
       </template>
       <template v-else>
-        <p class="text-muted m-0 mb-2 text-lg">No spaces match your filters</p>
-        <p class="text-faint m-0 text-sm">Try adjusting your filter criteria</p>
+        <p class="font-display text-navy m-0 mb-2 text-xl italic">Nothing matches.</p>
+        <p class="text-muted font-sans m-0 text-sm">Try clearing a filter.</p>
       </template>
     </div>
 
-    <!-- Space grid -->
-    <div v-else class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+    <!-- Single-column list with hairline rules between rows -->
+    <div v-else>
       <SpaceCard
         v-for="space in filteredAndSortedSpaces"
         :key="slugify(space.name)"

--- a/src/components/SpaceList.vue
+++ b/src/components/SpaceList.vue
@@ -88,7 +88,7 @@ const filteredAndSortedSpaces = computed(() => {
     <!-- Empty state -->
     <div
       v-if="filteredAndSortedSpaces.length === 0"
-      class="border-cool bg-cream-panel rounded-lg border-2 border-dashed px-6 py-12 text-center"
+      class="border-rule bg-paper-deep rounded-lg border-2 border-dashed px-6 py-12 text-center"
     >
       <template v-if="isOnlyOpenNowActive">
         <p class="text-muted m-0 mb-2 text-lg">Nothing open right now</p>

--- a/src/components/SpaceSummary.vue
+++ b/src/components/SpaceSummary.vue
@@ -113,8 +113,8 @@ function getNoiseStyle(level: string) {
         <h3
           :class="[
             compact
-              ? 'text-primary m-0 mb-1 text-lg font-bold'
-              : 'font-display text-primary m-0 mb-1 text-xl font-bold',
+              ? 'text-navy m-0 mb-1 text-lg font-bold'
+              : 'font-display text-navy m-0 mb-1 text-xl font-bold',
             visited && 'line-through opacity-70',
           ]"
         >
@@ -125,7 +125,7 @@ function getNoiseStyle(level: string) {
           :href="space.googleMapsUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-muted hover:text-accent focus-visible:ring-accent m-0 rounded text-sm hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          class="text-muted hover:text-rust focus-visible:ring-rust m-0 rounded text-sm hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           {{ space.address.split(',')[0] }}</a
         >
@@ -135,11 +135,11 @@ function getNoiseStyle(level: string) {
         <button
           @click="handleToggleVisited"
           v-tippy="visited ? 'Click to unmark' : 'Check off once you\'ve visited!'"
-          class="focus-visible:ring-accent flex h-7 w-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+          class="focus-visible:ring-rust flex h-7 w-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
           :class="
             visited
               ? 'border-green-500 bg-green-500 text-white'
-              : 'border-cool hover:border-accent hover:text-accent bg-white text-transparent'
+              : 'border-rule hover:border-rust hover:text-rust bg-white text-transparent'
           "
         >
           <span
@@ -153,7 +153,7 @@ function getNoiseStyle(level: string) {
         <span
           v-if="!space.verified"
           v-tippy="VERIFIED_DESCRIPTIONS.unverified"
-          class="text-accent cursor-help text-xs font-medium"
+          class="text-rust cursor-help text-xs font-medium"
         >
           ⚠️ Unverified
         </span>
@@ -177,7 +177,7 @@ function getNoiseStyle(level: string) {
         :href="verifyUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-accent focus-visible:ring-accent rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="text-rust focus-visible:ring-rust rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         Help verify it →
       </a>
@@ -210,8 +210,8 @@ function getNoiseStyle(level: string) {
       <span
         v-tippy="SEATING_DESCRIPTIONS[space.seatingType]"
         :class="[
-          'bg-cream-panel text-primary cursor-help rounded px-2 text-xs font-medium',
-          compact ? 'py-0.5' : 'border-warm border py-1',
+          'bg-paper-deep text-navy cursor-help rounded px-2 text-xs font-medium',
+          compact ? 'py-0.5' : 'border-rule border py-1',
         ]"
       >
         🪑 {{ SEATING_LABELS[space.seatingType] }}
@@ -243,7 +243,7 @@ function getNoiseStyle(level: string) {
     </div>
 
     <!-- Description -->
-    <div v-if="space.description" class="bg-cream-deep mt-3 rounded px-3 py-2">
+    <div v-if="space.description" class="bg-paper-deep mt-3 rounded px-3 py-2">
       <p class="text-body m-0 text-sm italic">"{{ space.description }}"</p>
     </div>
 
@@ -258,7 +258,7 @@ function getNoiseStyle(level: string) {
         :href="verifyUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-accent focus-visible:ring-accent ml-1 rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="text-rust focus-visible:ring-rust ml-1 rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         Help verify →
       </a>

--- a/src/components/SpaceSummary.vue
+++ b/src/components/SpaceSummary.vue
@@ -15,15 +15,17 @@ import {
 } from '../types/space'
 import { useVisitedSpaces } from '../composables/useVisitedSpaces'
 import { buildUpdateSpaceUrl } from '../utils/issueUrl'
+import AppIcon from './AppIcon.vue'
 
 interface Props {
   space: ICoworkingSpace
-  compact?: boolean // For map popup (smaller styling)
+  compact?: boolean
 }
 
 const props = defineProps<Props>()
 
 const verifyUrl = computed(() => buildUpdateSpaceUrl(props.space, 'verify'))
+const neighbourhood = computed(() => props.space.address.split(',')[0]?.trim() ?? '')
 
 const { isVisited, toggleVisited } = useVisitedSpaces()
 const visited = computed(() => isVisited(props.space.name))
@@ -39,229 +41,152 @@ function handleToggleVisited() {
   }
 }
 
-function getWifiColorHex(speed: string): string {
-  switch (speed) {
-    case 'fast':
-      return '#22c55e'
-    case 'medium':
-      return '#eab308'
-    case 'slow':
-      return '#ef4444'
-    default:
-      return '#9ca3af'
-  }
+function noiseIcon(level: string): string {
+  if (level === 'quiet') return 'volume-quiet'
+  if (level === 'loud') return 'volume-loud'
+  return 'volume-mid'
 }
 
-function getNoiseColorHex(level: string): string {
-  switch (level) {
-    case 'quiet':
-      return '#22c55e'
-    case 'medium':
-      return '#eab308'
-    case 'loud':
-      return '#ef4444'
-    default:
-      return '#9ca3af'
-  }
-}
-
-function getWifiClasses(speed: string): string {
-  switch (speed) {
-    case 'fast':
-      return 'bg-green-100 text-green-800 border-green-300'
-    case 'medium':
-      return 'bg-yellow-100 text-yellow-800 border-yellow-300'
-    case 'slow':
-      return 'bg-red-100 text-red-800 border-red-300'
-    default:
-      return 'bg-gray-100 text-gray-600 border-gray-300'
-  }
-}
-
-function getNoiseClasses(level: string): string {
-  switch (level) {
-    case 'quiet':
-      return 'bg-green-100 text-green-800 border-green-300'
-    case 'medium':
-      return 'bg-yellow-100 text-yellow-800 border-yellow-300'
-    case 'loud':
-      return 'bg-red-100 text-red-800 border-red-300'
-    default:
-      return 'bg-gray-100 text-gray-600 border-gray-300'
-  }
-}
-
-// For compact mode, we use inline styles; for full mode, we use Tailwind classes
-function getWifiStyle(speed: string) {
-  if (!props.compact) return undefined
-  const color = getWifiColorHex(speed)
-  return { backgroundColor: color + '20', color }
-}
-
-function getNoiseStyle(level: string) {
-  if (!props.compact) return undefined
-  const color = getNoiseColorHex(level)
-  return { backgroundColor: color + '20', color }
+function wifiIcon(speed: string): string {
+  return speed === 'unknown' ? 'wifi-off' : 'wifi'
 }
 </script>
 
 <template>
-  <div>
-    <!-- Header -->
+  <div :class="compact ? 'compact-summary' : 'entry-summary'">
+    <!-- Title row: name + neighbourhood + verified dot + visited button -->
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0 flex-1">
-        <h3
-          :class="[
-            compact
-              ? 'text-navy m-0 mb-1 text-lg font-bold'
-              : 'font-display text-navy m-0 mb-1 text-xl font-bold',
-            visited && 'line-through opacity-70',
-          ]"
-        >
-          <slot name="title">{{ space.name }}</slot>
-        </h3>
-
-        <a
-          :href="space.googleMapsUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-muted hover:text-rust focus-visible:ring-rust m-0 rounded text-sm hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-        >
-          {{ space.address.split(',')[0] }}</a
-        >
-      </div>
-      <div class="flex flex-shrink-0 flex-col items-end gap-2">
-        <!-- Visited checkbox -->
-        <button
-          @click="handleToggleVisited"
-          v-tippy="visited ? 'Click to unmark' : 'Check off once you\'ve visited!'"
-          class="focus-visible:ring-rust flex h-7 w-7 flex-shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-          :class="
-            visited
-              ? 'border-green-500 bg-green-500 text-white'
-              : 'border-rule hover:border-rust hover:text-rust bg-white text-transparent'
-          "
-        >
+        <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
           <span
-            class="text-sm transition-transform duration-200 motion-reduce:transition-none"
-            :class="{ 'scale-125': justChecked }"
+            v-if="space.verified"
+            v-tippy="VERIFIED_DESCRIPTIONS.verified"
+            class="bg-moss inline-block h-[7px] w-[7px] flex-shrink-0 cursor-help rounded-full"
+            aria-label="Verified"
+          />
+          <h3
+            :class="[
+              'font-display text-navy m-0 font-semibold tracking-tight',
+              compact ? 'text-lg leading-tight' : 'text-xl leading-tight sm:text-[22px]',
+              visited && 'opacity-60',
+            ]"
           >
-            {{ visited ? '✓' : '○' }}
-          </span>
-        </button>
-
-        <span
-          v-if="!space.verified"
-          v-tippy="VERIFIED_DESCRIPTIONS.unverified"
-          class="text-rust cursor-help text-xs font-medium"
-        >
-          ⚠️ Unverified
-        </span>
-        <span
-          v-else-if="!compact"
-          v-tippy="VERIFIED_DESCRIPTIONS.verified"
-          class="cursor-help text-xs font-medium text-green-600"
-        >
-          ✓ Verified
-        </span>
+            <slot name="title">{{ space.name }}</slot>
+          </h3>
+          <a
+            v-if="neighbourhood"
+            :href="space.googleMapsUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-muted hover:text-rust focus-visible:ring-rust font-sans text-xs hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            <span class="text-faint">·</span> {{ neighbourhood }}
+          </a>
+        </div>
       </div>
+
+      <!-- Visited toggle -->
+      <button
+        v-if="!compact"
+        type="button"
+        @click="handleToggleVisited"
+        v-tippy="visited ? 'Click to unmark' : 'Mark as visited'"
+        class="focus-visible:ring-rust flex h-6 w-6 flex-shrink-0 cursor-pointer items-center justify-center border transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+        :class="
+          visited
+            ? 'bg-rust border-rust text-paper'
+            : 'border-rule hover:border-rust text-transparent hover:text-rust bg-transparent'
+        "
+        :aria-pressed="visited"
+        :aria-label="visited ? 'Marked visited' : 'Mark visited'"
+      >
+        <AppIcon
+          name="check"
+          size="sm"
+          class="transition-transform duration-150 motion-reduce:transition-none"
+          :class="{ 'scale-110': justChecked }"
+        />
+      </button>
     </div>
 
-    <!-- Unverified banner -->
-    <div
-      v-if="!space.verified && !compact"
-      class="mt-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+    <!-- Unverified caption (only if !verified) -->
+    <p
+      v-if="!space.verified"
+      class="text-muted font-sans mt-1 text-xs"
     >
-      <span>📋 Not verified yet. </span>
+      Not verified yet.
       <a
         :href="verifyUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-rust focus-visible:ring-rust rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        class="text-ink hover:text-rust focus-visible:ring-rust border-b border-rust pb-px focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
-        Help verify it →
+        Help verify it
       </a>
-    </div>
-
-    <!-- Quick Tags -->
-    <div :class="compact ? 'mt-3 mb-3 flex flex-wrap gap-1.5' : 'mt-4 flex flex-wrap gap-2'">
-      <span
-        v-tippy="WIFI_SPEED_DESCRIPTIONS[space.wifiSpeed]"
-        :class="[
-          'cursor-help rounded px-2 text-xs font-medium',
-          compact ? 'py-0.5' : 'border py-1',
-          !compact && getWifiClasses(space.wifiSpeed),
-        ]"
-        :style="getWifiStyle(space.wifiSpeed)"
-      >
-        📶 {{ WIFI_SPEED_LABELS[space.wifiSpeed] }}
-      </span>
-      <span
-        v-tippy="NOISE_LEVEL_DESCRIPTIONS[space.noiseLevel]"
-        :class="[
-          'cursor-help rounded px-2 text-xs font-medium',
-          compact ? 'py-0.5' : 'border py-1',
-          !compact && getNoiseClasses(space.noiseLevel),
-        ]"
-        :style="getNoiseStyle(space.noiseLevel)"
-      >
-        🔊 {{ NOISE_LEVEL_LABELS[space.noiseLevel] }}
-      </span>
-      <span
-        v-tippy="SEATING_DESCRIPTIONS[space.seatingType]"
-        :class="[
-          'bg-paper-deep text-navy cursor-help rounded px-2 text-xs font-medium',
-          compact ? 'py-0.5' : 'border-rule border py-1',
-        ]"
-      >
-        🪑 {{ SEATING_LABELS[space.seatingType] }}
-      </span>
-      <span
-        v-if="space.hasAC === 'yes'"
-        v-tippy="AC_DESCRIPTIONS[space.hasAC]"
-        :class="[
-          'cursor-help rounded px-2 text-xs font-medium',
-          compact
-            ? 'bg-blue-100 py-0.5 text-blue-700'
-            : 'border border-blue-300 bg-blue-100 py-1 text-blue-800',
-        ]"
-      >
-        ❄️ AC
-      </span>
-      <span
-        v-if="space.foodAndDrinkAvailability !== 'none'"
-        v-tippy="FOOD_DESCRIPTIONS[space.foodAndDrinkAvailability]"
-        :class="[
-          'cursor-help rounded px-2 text-xs font-medium',
-          compact
-            ? 'bg-orange-100 py-0.5 text-orange-700'
-            : 'border border-orange-300 bg-orange-100 py-1 text-orange-800',
-        ]"
-      >
-        🍽️ {{ FOOD_LABELS[space.foodAndDrinkAvailability] }}
-      </span>
-    </div>
+    </p>
 
     <!-- Description -->
-    <div v-if="space.description" class="bg-paper-deep mt-3 rounded px-3 py-2">
-      <p class="text-body m-0 text-sm italic">"{{ space.description }}"</p>
-    </div>
-
-    <!-- Unverified notice -->
-    <div
-      v-if="!space.verified && compact"
-      v-tippy="VERIFIED_DESCRIPTIONS.unverified"
-      class="mb-3 cursor-help rounded border border-amber-200 bg-amber-50 px-2 py-1.5 text-xs text-amber-800"
+    <p
+      v-if="space.description"
+      :class="[
+        'font-desc text-ink m-0',
+        compact ? 'mt-2 text-sm' : 'mt-2 text-[15px] leading-relaxed',
+        visited && 'opacity-70',
+      ]"
     >
-      ⚠️ Unverified
-      <a
-        :href="verifyUrl"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-rust focus-visible:ring-rust ml-1 rounded font-semibold hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      {{ space.description }}
+    </p>
+
+    <!-- Meta strip: icon-pill metadata, separated by · -->
+    <div
+      :class="[
+        'font-sans text-muted flex flex-wrap items-center text-[11px] font-medium tracking-[0.06em] uppercase',
+        compact ? 'mt-2 gap-x-2 gap-y-1' : 'mt-3 gap-x-2.5 gap-y-1.5',
+      ]"
+    >
+      <span
+        v-tippy="WIFI_SPEED_DESCRIPTIONS[space.wifiSpeed]"
+        class="inline-flex cursor-help items-center gap-1"
       >
-        Help verify →
-      </a>
+        <AppIcon :name="wifiIcon(space.wifiSpeed)" size="sm" />
+        {{ WIFI_SPEED_LABELS[space.wifiSpeed] }} wifi
+      </span>
+      <span class="text-rule">·</span>
+      <span
+        v-tippy="NOISE_LEVEL_DESCRIPTIONS[space.noiseLevel]"
+        class="inline-flex cursor-help items-center gap-1"
+      >
+        <AppIcon :name="noiseIcon(space.noiseLevel)" size="sm" />
+        {{ NOISE_LEVEL_LABELS[space.noiseLevel] }}
+      </span>
+      <span class="text-rule">·</span>
+      <span
+        v-tippy="SEATING_DESCRIPTIONS[space.seatingType]"
+        class="inline-flex cursor-help items-center gap-1"
+      >
+        <AppIcon name="armchair" size="sm" />
+        {{ SEATING_LABELS[space.seatingType] }}
+      </span>
+      <template v-if="space.hasAC === 'yes'">
+        <span class="text-rule">·</span>
+        <span
+          v-tippy="AC_DESCRIPTIONS[space.hasAC]"
+          class="inline-flex cursor-help items-center gap-1"
+        >
+          <AppIcon name="snowflake" size="sm" />
+          AC
+        </span>
+      </template>
+      <template v-if="space.foodAndDrinkAvailability !== 'none'">
+        <span class="text-rule">·</span>
+        <span
+          v-tippy="FOOD_DESCRIPTIONS[space.foodAndDrinkAvailability]"
+          class="inline-flex cursor-help items-center gap-1"
+        >
+          <AppIcon name="utensils" size="sm" />
+          {{ FOOD_LABELS[space.foodAndDrinkAvailability] }}
+        </span>
+      </template>
     </div>
   </div>
 </template>

--- a/src/components/TodayView.vue
+++ b/src/components/TodayView.vue
@@ -34,10 +34,10 @@ const picks = computed(() => getFeaturedSpaces(props.spaces))
 <template>
   <section v-if="picks.length > 0" class="mb-6" aria-label="Today's featured coworking spaces">
     <div class="mb-3 flex items-center justify-between">
-      <h2 class="font-display text-primary m-0 text-lg font-bold sm:text-xl">Today's picks</h2>
+      <h2 class="font-display text-navy m-0 text-lg font-bold sm:text-xl">Today's picks</h2>
       <button
         type="button"
-        class="text-muted hover:text-primary focus-visible:ring-accent flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
+        class="text-muted hover:text-navy focus-visible:ring-rust flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
         :aria-expanded="!collapsed"
         :aria-label="collapsed ? 'Show today\'s picks' : 'Hide today\'s picks'"
         @click="collapsed = !collapsed"

--- a/src/components/TodayView.vue
+++ b/src/components/TodayView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { computed } from 'vue'
 import type { ICoworkingSpace } from '../types/space'
 import { getFeaturedSpaces } from '../utils/featuredSpaces'
 import FeaturedCard from './FeaturedCard.vue'
@@ -10,50 +10,28 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const STORAGE_KEY = 'todayView.collapsed'
-const collapsed = ref(false)
-
-try {
-  collapsed.value = localStorage.getItem(STORAGE_KEY) === '1'
-} catch {
-  collapsed.value = false
-}
-
-watch(collapsed, (val) => {
-  try {
-    if (val) localStorage.setItem(STORAGE_KEY, '1')
-    else localStorage.removeItem(STORAGE_KEY)
-  } catch {
-    // ignore storage failures
-  }
-})
-
 const picks = computed(() => getFeaturedSpaces(props.spaces))
 </script>
 
 <template>
-  <section v-if="picks.length > 0" class="mb-6" aria-label="Today's featured coworking spaces">
-    <div class="mb-3 flex items-center justify-between">
-      <h2 class="font-display text-navy m-0 text-lg font-bold sm:text-xl">Today's picks</h2>
-      <button
-        type="button"
-        class="text-muted hover:text-navy focus-visible:ring-rust flex items-center gap-1 rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none motion-reduce:transition-none"
-        :aria-expanded="!collapsed"
-        :aria-label="collapsed ? 'Show today\'s picks' : 'Hide today\'s picks'"
-        @click="collapsed = !collapsed"
+  <section
+    v-if="picks.length > 0"
+    class="mt-6 mb-2 sm:mb-4"
+    aria-label="Today's featured coworking spaces"
+  >
+    <div class="mb-3 flex items-baseline justify-between gap-3">
+      <h2 class="font-display text-navy m-0 text-base font-semibold italic sm:text-lg">
+        Today's picks
+      </h2>
+      <span
+        class="font-mono text-muted text-[10px] tracking-[0.06em] uppercase"
+        aria-hidden="true"
       >
-        <span>{{ collapsed ? 'Show' : 'Hide' }}</span>
-        <span
-          aria-hidden="true"
-          class="inline-block transition-transform motion-reduce:transition-none"
-          :class="{ 'rotate-180': !collapsed }"
-        >
-          ▼
-        </span>
-      </button>
+        {{ picks.length }} of {{ spaces.length }} · rotates daily
+      </span>
     </div>
 
-    <div v-show="!collapsed" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <FeaturedCard v-for="pick in picks" :key="pick.slot" :pick="pick" />
     </div>
   </section>

--- a/src/components/ViewSegmented.vue
+++ b/src/components/ViewSegmented.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import AppIcon from './AppIcon.vue'
+
+type ViewMode = 'list' | 'map'
+
+interface Props {
+  modelValue: ViewMode
+}
+
+defineProps<Props>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: ViewMode): void
+}>()
+
+function setMode(mode: ViewMode) {
+  emit('update:modelValue', mode)
+}
+</script>
+
+<template>
+  <div
+    class="border-navy inline-flex w-full border bg-white sm:w-auto"
+    role="tablist"
+    aria-label="View mode"
+  >
+    <button
+      type="button"
+      role="tab"
+      :aria-selected="modelValue === 'list'"
+      class="font-sans text-ink hover:bg-paper-deep focus-visible:ring-rust inline-flex flex-1 cursor-pointer items-center justify-center gap-1.5 border-0 bg-transparent px-4 py-2 text-xs font-medium tracking-[0.04em] uppercase transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none sm:flex-none"
+      :class="modelValue === 'list' ? 'bg-navy text-paper hover:bg-navy' : ''"
+      @click="setMode('list')"
+    >
+      <AppIcon name="list" size="sm" />
+      List
+    </button>
+    <button
+      type="button"
+      role="tab"
+      :aria-selected="modelValue === 'map'"
+      class="border-navy font-sans text-ink hover:bg-paper-deep focus-visible:ring-rust inline-flex flex-1 cursor-pointer items-center justify-center gap-1.5 border-0 border-l bg-transparent px-4 py-2 text-xs font-medium tracking-[0.04em] uppercase transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset motion-reduce:transition-none sm:flex-none"
+      :class="modelValue === 'map' ? 'bg-navy text-paper hover:bg-navy' : ''"
+      @click="setMode('map')"
+    >
+      <AppIcon name="map-pin" size="sm" />
+      Map
+    </button>
+  </div>
+</template>

--- a/src/components/VisitProgress.vue
+++ b/src/components/VisitProgress.vue
@@ -46,7 +46,7 @@ async function copyShareLink() {
   <Transition name="slide-up">
     <div
       v-if="visitedCount > 0"
-      class="bg-primary fixed right-0 bottom-0 left-0 z-50 text-white shadow-lg"
+      class="bg-navy fixed right-0 bottom-0 left-0 z-50 text-white shadow-lg"
     >
       <div class="mx-auto max-w-6xl px-6 py-3">
         <div class="flex items-center justify-between gap-4">
@@ -56,11 +56,11 @@ async function copyShareLink() {
               <p class="m-0 text-sm font-medium">
                 {{ message }}
               </p>
-              <p class="text-cool m-0 text-xs">
+              <p class="text-faint m-0 text-xs">
                 {{ visitedCount }} of {{ totalSpaces }} spaces visited ·
                 <button
                   v-tippy="'Bookmark this link to restore your progress'"
-                  class="text-cool focus-visible:ring-accent cursor-pointer rounded border-0 bg-transparent p-0 underline transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
+                  class="text-faint focus-visible:ring-rust cursor-pointer rounded border-0 bg-transparent p-0 underline transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
                   :class="{ 'text-green-400 hover:text-green-400': copyStatus === 'copied' }"
                   @click="copyShareLink"
                 >
@@ -74,13 +74,13 @@ async function copyShareLink() {
 
           <!-- Progress bar -->
           <div class="flex min-w-0 flex-1 items-center gap-3">
-            <div class="bg-primary-track h-3 flex-1 overflow-hidden rounded-full">
+            <div class="bg-navy-track h-3 flex-1 overflow-hidden rounded-full">
               <div
-                class="bg-accent h-full rounded-full transition-all duration-500 ease-out motion-reduce:transition-none"
+                class="bg-rust h-full rounded-full transition-all duration-500 ease-out motion-reduce:transition-none"
                 :style="{ width: `${percentage}%` }"
               />
             </div>
-            <span class="text-cool flex-shrink-0 text-xs">{{ percentage }}%</span>
+            <span class="text-faint flex-shrink-0 text-xs">{{ percentage }}%</span>
           </div>
         </div>
       </div>

--- a/src/components/VisitProgress.vue
+++ b/src/components/VisitProgress.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useVisitedSpaces } from '../composables/useVisitedSpaces'
+import AppIcon from './AppIcon.vue'
 
 interface Props {
   totalSpaces: number
@@ -14,16 +15,6 @@ const percentage = computed(() => {
   return Math.round((visitedCount.value / props.totalSpaces) * 100)
 })
 
-const message = computed(() => {
-  if (visitedCount.value === 0) return ''
-  if (visitedCount.value === 1) return "You've started your Leuven coworking journey! ☕"
-  if (percentage.value === 100) return "🎉 You've visited every spot! True coworking champion!"
-  if (percentage.value >= 75) return "Almost there! You're a Leuven coworking pro! 🌟"
-  if (percentage.value >= 50) return 'Halfway through! Keep exploring! 🚀'
-  if (percentage.value >= 25) return 'Great progress! So many spots to discover! 📍'
-  return "Keep exploring Leuven's coworking scene! 🗺️"
-})
-
 const copyStatus = ref<'idle' | 'copied'>('idle')
 
 async function copyShareLink() {
@@ -35,7 +26,6 @@ async function copyShareLink() {
       copyStatus.value = 'idle'
     }, 2000)
   } catch {
-    // Fallback for browsers without clipboard API
     const url = getShareableUrl()
     prompt('Copy this link to save your progress:', url)
   }
@@ -46,42 +36,43 @@ async function copyShareLink() {
   <Transition name="slide-up">
     <div
       v-if="visitedCount > 0"
-      class="bg-navy fixed right-0 bottom-0 left-0 z-50 text-white shadow-lg"
+      class="bg-paper border-rule fixed right-0 bottom-0 left-0 z-50 border-t"
     >
-      <div class="mx-auto max-w-6xl px-6 py-3">
-        <div class="flex items-center justify-between gap-4">
-          <div class="flex flex-shrink-0 items-center gap-3">
-            <span class="text-2xl">{{ percentage === 100 ? '🏆' : '✅' }}</span>
-            <div class="min-w-[280px] sm:min-w-[340px]">
-              <p class="m-0 text-sm font-medium">
-                {{ message }}
-              </p>
-              <p class="text-faint m-0 text-xs">
-                {{ visitedCount }} of {{ totalSpaces }} spaces visited ·
-                <button
-                  v-tippy="'Bookmark this link to restore your progress'"
-                  class="text-faint focus-visible:ring-rust cursor-pointer rounded border-0 bg-transparent p-0 underline transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none"
-                  :class="{ 'text-green-400 hover:text-green-400': copyStatus === 'copied' }"
-                  @click="copyShareLink"
-                >
-                  {{
-                    copyStatus === 'copied' ? 'copied link to clipboard!' : 'copy my progress link'
-                  }}
-                </button>
-              </p>
-            </div>
+      <div class="mx-auto max-w-6xl px-5 py-3 sm:px-6">
+        <div class="font-sans text-ink flex flex-wrap items-center gap-x-4 gap-y-2 text-[13px]">
+          <span class="text-rust flex-shrink-0" aria-hidden="true">
+            <AppIcon name="check" />
+          </span>
+          <p class="m-0 flex flex-shrink-0 items-baseline gap-1.5 font-medium">
+            <span class="font-display text-navy text-base font-semibold italic">
+              {{ visitedCount }}
+            </span>
+            <span class="text-muted text-xs font-normal">of {{ totalSpaces }}</span>
+            visited
+          </p>
+          <div
+            class="bg-rule-soft order-5 h-[3px] w-full min-w-0 flex-1 sm:order-3"
+            role="progressbar"
+            :aria-valuenow="percentage"
+            aria-valuemin="0"
+            aria-valuemax="100"
+          >
+            <div
+              class="bg-rust h-full transition-[width] duration-500 ease-out motion-reduce:transition-none"
+              :style="{ width: `${percentage}%` }"
+            />
           </div>
-
-          <!-- Progress bar -->
-          <div class="flex min-w-0 flex-1 items-center gap-3">
-            <div class="bg-navy-track h-3 flex-1 overflow-hidden rounded-full">
-              <div
-                class="bg-rust h-full rounded-full transition-all duration-500 ease-out motion-reduce:transition-none"
-                :style="{ width: `${percentage}%` }"
-              />
-            </div>
-            <span class="text-faint flex-shrink-0 text-xs">{{ percentage }}%</span>
-          </div>
+          <span class="font-mono text-muted order-3 flex-shrink-0 text-xs sm:order-4">
+            {{ percentage }}%
+          </span>
+          <button
+            type="button"
+            class="text-ink hover:text-rust focus-visible:ring-rust border-rust order-4 flex-shrink-0 cursor-pointer border-0 border-b bg-transparent p-0 pb-px text-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-reduce:transition-none sm:order-5"
+            v-tippy="'Bookmark this link to restore your progress on another device'"
+            @click="copyShareLink"
+          >
+            {{ copyStatus === 'copied' ? 'copied' : 'copy progress link' }}
+          </button>
         </div>
       </div>
     </div>
@@ -100,5 +91,16 @@ async function copyShareLink() {
 .slide-up-leave-to {
   transform: translateY(100%);
   opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slide-up-enter-active,
+  .slide-up-leave-active {
+    transition: opacity 0.1s ease;
+  }
+  .slide-up-enter-from,
+  .slide-up-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -1,35 +1,56 @@
 @import 'tailwindcss';
 
 @theme {
-  /* Brand */
-  --color-primary: #1a365d;
-  --color-primary-hover: #15284a;
-  --color-primary-track: #2d4a7c;
-  --color-accent: #ed8936;
-  --color-accent-hover: #dd7826;
+  /* Type — registered as Tailwind font-* utilities */
+  --font-display: 'Fraunces', Georgia, serif;
+  --font-serif: 'Source Serif 4', Georgia, serif;
+  --font-sans: 'IBM Plex Sans', system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* Surfaces */
-  --color-cream: #fffaf0;
-  --color-cream-panel: #f5f0e6;
-  --color-cream-deep: #faf5eb;
+  --color-paper: #fffaf0;
+  --color-paper-deep: #faf5eb;
+  --color-rule: #d8c9ad;
+  --color-rule-soft: #ede2cc;
 
-  /* Borders */
-  --color-warm: #e2d9c8;
-  --color-cool: #cbd5e0;
+  /* Brand */
+  --color-navy: #1a365d;
+  --color-navy-hover: #15284a;
+  --color-rust: #c75f1c;
+  --color-rust-hover: #a64f10;
+  --color-moss: #5c6b3c;
 
   /* Text */
   --color-ink: #1a202c;
   --color-body: #4a5568;
-  --color-muted: #718096;
-  --color-faint: #a0aec0;
+  --color-muted: #5f6470;
+  --color-faint: #9da3ae;
+
+  /* Legacy aliases — retained until Phase 1 class-rename sweep completes */
+  --color-primary: #1a365d;
+  --color-primary-hover: #15284a;
+  --color-primary-track: #2d4a7c;
+  --color-accent: #c75f1c;
+  --color-accent-hover: #a64f10;
+  --color-cream: #fffaf0;
+  --color-cream-panel: #faf5eb;
+  --color-cream-deep: #faf5eb;
+  --color-warm: #d8c9ad;
+  --color-cool: #cbd5e0;
 }
 
 body {
-  font-family: 'Crimson Pro', Georgia, serif;
-  background-color: var(--color-cream);
+  font-family: 'Source Serif 4', Georgia, serif;
+  background-color: var(--color-paper);
   color: var(--color-ink);
+  -webkit-font-smoothing: antialiased;
 }
 
 .font-display {
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Fraunces', Georgia, serif;
+}
+
+.font-desc {
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-style: italic;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -16,6 +16,7 @@
   /* Brand */
   --color-navy: #1a365d;
   --color-navy-hover: #15284a;
+  --color-navy-track: #2d4a7c;
   --color-rust: #c75f1c;
   --color-rust-hover: #a64f10;
   --color-moss: #5c6b3c;
@@ -25,18 +26,6 @@
   --color-body: #4a5568;
   --color-muted: #5f6470;
   --color-faint: #9da3ae;
-
-  /* Legacy aliases — retained until Phase 1 class-rename sweep completes */
-  --color-primary: #1a365d;
-  --color-primary-hover: #15284a;
-  --color-primary-track: #2d4a7c;
-  --color-accent: #c75f1c;
-  --color-accent-hover: #a64f10;
-  --color-cream: #fffaf0;
-  --color-cream-panel: #faf5eb;
-  --color-cream-deep: #faf5eb;
-  --color-warm: #d8c9ad;
-  --color-cool: #cbd5e0;
 }
 
 body {


### PR DESCRIPTION
## Summary

Tightening pass on the visual design after the user's feedback that the site felt "a bit too AI." 9 commits, 19 files changed (+1099 / -804). Build passes, all 59 tests pass, /review clean.

**The design moves:**
- Drop the Halloween orange `#ed8936` for a darker rust `#c75f1c` (Leuven roof tiles, less Stripe dashboard)
- Drop Playfair Display + Crimson Pro for **Fraunces** (display) + **Source Serif 4** (descriptions, italic) + **IBM Plex Sans** (UI chrome) + **IBM Plex Mono** (data stamps)
- Replace 5 of 8 emoji prefixes with **Lucide icons** via inline SVG `<symbol>` definitions. Weather emoji on `OpenNowChip` stays — that one is earned.
- Strip AskBar's ✨ sparkle + bouncing "Thinking" dots. Restyle as a label-above-input with a rust underline. Rotating placeholder examples preserved (respects `prefers-reduced-motion`).
- Replace the dual-card footer with an **asymmetric editorial marketing callout** for the Leuven coworking group (the actual conversion CTA — site is a marketing funnel for the group). Quiet inline footer line keeps the contribution links.
- Drop the navy header bar. Page becomes a single editorial column with a Fraunces masthead + italic field-guide subtitle.
- Restructure: **Today's picks** (3 daily-rotating flip cards with photo strips, Lucide pill icons) is now visually subordinate to **All spots** (the main filterable list) — separated by a section header with a prominent navy List/Map segmented toggle that goes full-width on mobile.
- List rows lose their `rounded-lg border-2` cards. Hairline rules between rows. Photo on left (88px desktop, 64px mobile), summary middle, expandable detail block.
- VisitProgress strips the gamification copy. Replaced with a neutral count + thin rust progress rule + mono percentage. URL-shareable progress preserved.
- MapView gets custom 22×22 rust pins (paper border, paper center dot) replacing the default blue Leaflet droplets. Tile layer switches from saturated OSM to **Stadia Stamen Toner Lite** grayscale, matching the cream paper feel.
- Subtitle: *"A small Leuven field guide to cafés where it's nice to open a laptop."*

**Mobile fixes:**
- Pick cards on mobile use a compact horizontal layout (photo on left, ~128px tall) — was 288px tall, fixed during /qa pass.
- List entry photos drop to 64×64, last-visited stamp moves below the entry on a dashed rule
- Map view goes full-width on mobile
- Filter tabs wrap, view toggle stretches full-width above the All-spots heading

## Commits (bisectable)

| Phase | Commit |
|---|---|
| 0 | :lipstick: Switch fonts + palette tokens to editorial system |
| spec | :memo: Update DESIGN.md for editorial tightening pass |
| 1 | :truck: Rename Tailwind tokens across components |
| 2 | :sparkles: Add Lucide icon set as inline SVG symbols |
| 3 | :lipstick: Strip AskBar AI theatre |
| 4 | :art: Restyle list rows and Today's-pick cards to editorial layout |
| 5+6 | :building_construction: Restructure App layout, add marketing callout + footer + segmented toggle |
| 7 | :world_map: Custom rust pins + grayscale tiles in MapView |
| qa | :bug: Compact FeaturedCard on mobile (photo on left) |

## Pre-Landing Review

`/review` ran clean against `2940b93`. PR Quality Score 9.5 / 10.

- 0 critical findings
- 3 informational, all skipped (non-blocking):
  - DRY hash function across SpaceCard + FeaturedCard (4-line djb2, gradient pools differ — extracting saves nothing)
  - 5 new components without unit tests (project has no Vue component test framework, behavioral logic is covered)
  - Pre-existing `simpleanalyticscdn.com` blocked in headless (not introduced by this PR)

Adversarial pass: walked the diff for failure modes (Stadia attribution, Lucide fragment URL resolution, NaN guard, clipboard fallback, divIcon HTML injection surface). No production failure modes introduced.

## Design Review

This PR is the implementation of `/design-consultation` (6 design preview iterations approved by the user). `/qa` then verified the rendered result and found one mobile bug, fixed in commit `2940b93`. DESIGN.md updated to reflect the new system in commit `0cdf1ab`.

## Test Coverage

```
3 test suites, 59 tests, 0 failures
```

This PR is a visual + token rename. New behavioral logic is limited to:
- AskBar `prefers-reduced-motion` placeholder gating
- VisitProgress restyle (logic unchanged from main — only rendering)
- MapView custom `divIcon` markers (replacing default markers)
- FeaturedCard mobile responsive layout

All existing tests pass against the merged code.

## QA verification

`/qa` ran in the browser at desktop (1280×900) and mobile (390×844):
- AskBar: rotating placeholder, multi-phrase parsing ("quiet, fast wifi, ac" → 3 chips → URL sync → list filters to 1 entry)
- Today's picks: 3 flip cards, deterministic gradients, click flips to back face
- More filters disclosure: 7 select dropdowns + sort
- Visit toggle → VisitProgress bar with neutral count
- Map view: 42 custom rust pins on Stadia tiles, popup with SpaceSummary
- Marketing CTA: "Join the group" → correct URL
- Footer: contribution links resolve, "42 cafés · last updated 30 apr 2026" data stamp
- Mobile: section-header column-reverse, segmented toggle full-width, entry photos 64px, map full-width, **pick cards 350×128 (was 350×288 before /qa fix)**

Health score: 95/100 after fix.

## Plan Completion

8 phases from `.context/implementation-plan.md`:
- ✅ Phase 0: Foundation (fonts + tokens)
- ✅ Phase 1: Tailwind class rename sweep
- ✅ Phase 2: Lucide icon SVG symbols
- ✅ Phase 3: AskBar AI-theatre stripped
- ✅ Phase 4: SpaceCard / SpaceSummary / FeaturedCard / TodayView restyled
- ✅ Phase 5+6: App layout + ViewSegmented + CoworkingGroupCallout + SiteFooter + VisitProgress
- ✅ Phase 7: MapView custom pins + grayscale tiles
- ✅ Phase 8: Cleanup + ship

## Open follow-ups (tracked in DESIGN.md)

1. **Photos**: pick cards + list rows currently use deterministic gradient placeholders. Real café photos require an `imageUrl?: string` field on `ICoworkingSpace`.
2. **Map list-on-left for desktop**: mockup exists in `.context/design-preview.html`, not implemented (map currently fills the container).
3. **Optional `tipNotes` and `lastVisitedAt` fields**: design reserves space for "Tip · …" callouts and mono date stamps; would populate where data exists.

## Test plan
- [x] All 59 vitest tests pass
- [x] Production build succeeds (`bun run build`, 380kB)
- [x] /review CLEAN (quality 9.5/10)
- [x] /qa verified at desktop + mobile widths
- [x] Map view renders custom rust pins + grayscale tiles + working popups
- [x] Visit progress + URL share link work
- [x] AskBar parser end-to-end (typing → matched chips → list filter → URL sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)