### PR TITLE
:bug: Render pill tags on featured cards with long descriptions

### DIFF
--- a/src/components/FeaturedCard.vue
+++ b/src/components/FeaturedCard.vue
@@ -91,7 +91,9 @@ function toggle() {
             class="h-full w-full object-cover"
           />
         </div>
-        <div class="flex flex-1 flex-col gap-1 p-3 sm:gap-2 sm:p-5">
+        <div
+          class="relative flex flex-1 flex-col gap-1 overflow-hidden p-3 sm:gap-2 sm:p-5 sm:pb-[46px]"
+        >
           <span
             class="text-rust font-sans text-[9.5px] font-medium tracking-[0.14em] uppercase sm:text-[10px] sm:tracking-[0.16em]"
           >
@@ -102,15 +104,15 @@ function toggle() {
           >
             {{ pick.space.name }}
           </h3>
-          <p class="font-desc text-muted m-0 hidden text-[12.5px] sm:block">{{ pick.hook }}</p>
+          <p class="font-desc text-muted m-0 text-[12.5px] max-sm:hidden">{{ pick.hook }}</p>
           <p
-            class="font-desc text-ink m-0 line-clamp-2 hidden text-[13.5px] leading-relaxed sm:block"
+            class="font-desc text-ink m-0 line-clamp-2 text-[13.5px] leading-relaxed max-sm:hidden"
           >
             {{ firstSentence }}
           </p>
 
           <div
-            class="border-rule-soft mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-1.5 text-[9.5px] sm:gap-x-2.5 sm:border-t sm:pt-2 sm:text-[10px]"
+            class="border-rule-soft mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 pt-1.5 text-[9.5px] sm:absolute sm:right-5 sm:bottom-4 sm:left-5 sm:gap-x-2.5 sm:border-t sm:pt-2 sm:text-[10px]"
           >
             <template v-for="(pill, i) in pills" :key="pill.label">
               <span
@@ -121,12 +123,6 @@ function toggle() {
               </span>
               <span v-if="i < pills.length - 1" class="text-rule">·</span>
             </template>
-            <span
-              aria-hidden="true"
-              class="text-faint ml-auto hidden pl-2 font-mono text-[9px] tracking-wide sm:inline"
-            >
-              tap to flip ↻
-            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Today's picks cards weren't rendering their pill tags (e.g. `QUIET · FAST WIFI · FULL MENU`) when the space's first description sentence wrapped to two lines. Komfort was the visible case at the time of writing, but the issue would hit any space with a long-enough first sentence.

**Root cause:** the description's `line-clamp-2` utility wasn't actually clipping. Tailwind v4 emits `line-clamp` as `display: -webkit-box`, but the sibling `sm:block` set `display: block` and won, so the description rendered at full natural height. With the card pinned at `h-72` and `overflow-hidden`, the pills row got pushed below the visible area on cards with longer descriptions.

**Fix in `src/components/FeaturedCard.vue`:**
- Replaced `hidden ... sm:block` with `max-sm:hidden` on the hook + description so display utilities don't fight `line-clamp`.
- Made the content column `relative overflow-hidden` with reserved bottom padding (`sm:pb-[46px]`) and pinned the pills row to `sm:absolute sm:bottom-4 sm:left-5 sm:right-5`, so pills always render regardless of description length.
- Removed the `tap to flip ↻` hint that was forcing the pills row to wrap to a second line and overlap the description (cursor + aria-label already convey interactivity; the back face still has its `tap to flip back ↺` hint).

## Test plan
- [x] `bun run test` — 59 tests pass
- [x] `bun run build` — builds clean (vue-tsc + vite)
- [x] `bun run format:check` — Prettier clean
- [x] Verified at desktop (1280×800, 1440×900) and mobile (390×844) — all three of today's picks render their pill tags
- [x] Card flip still works (front ↔ back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)