### PR TITLE
:lipstick: Distinguish visited and unverified spaces visually

### DIFF
--- a/src/components/SpaceCard.vue
+++ b/src/components/SpaceCard.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { type ICoworkingSpace, OUTLET_LABELS, OUTLET_DESCRIPTIONS } from '../types/space'
 import { slugify } from '../utils/slug'
 import { buildUpdateSpaceUrl } from '../utils/issueUrl'
+import { useVisitedSpaces } from '../composables/useVisitedSpaces'
 import SpaceSummary from './SpaceSummary.vue'
 
 interface Props {
@@ -13,6 +14,9 @@ const props = defineProps<Props>()
 
 const expanded = ref(false)
 const updateUrl = computed(() => buildUpdateSpaceUrl(props.space))
+
+const { isVisited } = useVisitedSpaces()
+const visited = computed(() => isVisited(props.space.name))
 
 // Deterministic gradient placeholder until imageUrl exists.
 const photoGradient = computed(() => {
@@ -31,8 +35,8 @@ const photoGradient = computed(() => {
 
 <template>
   <article
-    class="entry border-rule-soft hover:bg-rust/[0.03] grid grid-cols-[64px_1fr] gap-3 border-b px-3 py-5 transition-colors motion-reduce:transition-none sm:grid-cols-[88px_1fr] sm:gap-5 sm:px-4"
-    :class="{ 'opacity-70': !space.verified }"
+    class="entry border-rule-soft hover:bg-rust/[0.03] grid grid-cols-[64px_1fr] gap-3 border-b px-3 py-5 transition-all duration-200 motion-reduce:transition-none sm:grid-cols-[88px_1fr] sm:gap-5 sm:px-4"
+    :class="{ 'opacity-45 grayscale hover:opacity-100 hover:grayscale-0': visited }"
   >
     <div
       class="entry-photo h-[64px] w-[64px] flex-shrink-0 overflow-hidden sm:h-[88px] sm:w-[88px]"

--- a/src/components/SpaceSummary.vue
+++ b/src/components/SpaceSummary.vue
@@ -68,7 +68,7 @@ function wifiIcon(speed: string): string {
             :class="[
               'font-display text-navy m-0 font-semibold tracking-tight',
               compact ? 'text-lg leading-tight' : 'text-xl leading-tight sm:text-[22px]',
-              visited && 'opacity-60',
+              visited && 'line-through decoration-rust/40 decoration-[1.5px]',
             ]"
           >
             <slot name="title">{{ space.name }}</slot>
@@ -128,7 +128,6 @@ function wifiIcon(speed: string): string {
       :class="[
         'font-desc text-ink m-0',
         compact ? 'mt-2 text-sm' : 'mt-2 text-[15px] leading-relaxed',
-        visited && 'opacity-70',
       ]"
     >
       {{ space.description }}


### PR DESCRIPTION
## Summary

Unverified and visited spaces previously both rendered with a subtle opacity fade, so they looked nearly identical when scanning the list. Flipped the treatment so visited spaces clearly recede and unverified spaces stay easy to scan.

**Visited cards** (`SpaceCard.vue`): now fade the entire `<article>` to 45% opacity + apply grayscale to the photo, with hover restoring full color. Title gets a rust-tinted strikethrough. The whole card visually recedes.

**Unverified cards** (`SpaceCard.vue`): removed the `opacity-70` that previously washed them out. They now render at full strength. The differentiator from verified is the absent moss "verified" dot and the small "Not verified yet" caption — both already in place.

**`SpaceSummary.vue`**: dropped the per-element `opacity-60`/`opacity-70` on title/description for visited spaces — the card-level treatment replaces them.

Net effect: the list scans cleanly for "what should I visit next" as the primary axis, with verification status as the secondary signal.

## Test plan

- [x] Vitest suite passes (73/73)
- [x] `npm run build` passes (type check + production build)
- [x] Visual verification in dev server: visited cards (grayscale + 45% + strikethrough) clearly distinct from unverified-unvisited (full color, no dot, "Not verified yet" caption) and from verified-unvisited (full color, moss dot)
- [x] Hover restores visited cards to full color so details remain readable on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)